### PR TITLE
feat: simplify type conversion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.6.0 - 2021-MM-DD
+==========================
+
+- Handle type conversion via fields
+
 Version 0.5.2 - 2021-06-03
 ==========================
 

--- a/src/shillelagh/adapters/api/weatherapi.py
+++ b/src/shillelagh/adapters/api/weatherapi.py
@@ -135,8 +135,12 @@ class WeatherAPI(Adapter):
                 columns = self.get_columns()
                 for record in hourly_data:
                     row = {column: record[column] for column in columns}
-                    row["time"] = dateutil.parser.parse(record["time"]).replace(
-                        tzinfo=tz,
+                    row["time"] = (
+                        dateutil.parser.parse(record["time"])
+                        .replace(
+                            tzinfo=tz,
+                        )
+                        .isoformat()
                     )
                     row["rowid"] = int(row["time_epoch"])
                     yield row

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -154,6 +154,7 @@ class Cursor(object):
         if not self.description:
             return
 
+        # convert from SQLite types (ISO string for datetime, eg) to native Python types
         for row in cursor:
             yield tuple(desc[1].parse(col) for col, desc in zip(row, self.description))
 

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -59,6 +59,10 @@ class Field:
     def parse(value: Any) -> Any:
         raise NotImplementedError("Subclasses must implement `parse`")
 
+    @staticmethod
+    def quote(value: Any) -> str:
+        raise NotImplementedError("Subclasses must implement `quote`")
+
 
 class Integer(Field):
     type = "INTEGER"
@@ -70,6 +74,10 @@ class Integer(Field):
             return None
 
         return int(value)
+
+    @staticmethod
+    def quote(value: Any) -> str:
+        return str(value)
 
 
 class Float(Field):
@@ -83,6 +91,10 @@ class Float(Field):
 
         return float(value)
 
+    @staticmethod
+    def quote(value: Any) -> str:
+        return str(value)
+
 
 class String(Field):
     type = "TEXT"
@@ -94,6 +106,11 @@ class String(Field):
             return None
 
         return str(value)
+
+    @staticmethod
+    def quote(value: Any) -> str:
+        escaped_value = value.replace("'", "''")
+        return f"'{escaped_value}'"
 
 
 class Date(Field):
@@ -115,6 +132,10 @@ class Date(Field):
 
         return dt.astimezone(datetime.timezone.utc).date()
 
+    @staticmethod
+    def quote(value: Any) -> str:
+        return f"'{value.isoformat()}'"
+
 
 class Time(Field):
     type = "TIME"
@@ -134,6 +155,10 @@ class Time(Field):
             dt = dt.replace(tzinfo=datetime.timezone.utc)
 
         return dt.astimezone(datetime.timezone.utc).timetz()
+
+    @staticmethod
+    def quote(value: Any) -> str:
+        return f"'{value.isoformat()}'"
 
 
 class DateTime(Field):
@@ -155,6 +180,10 @@ class DateTime(Field):
 
         return dt.astimezone(datetime.timezone.utc)
 
+    @staticmethod
+    def quote(value: Any) -> str:
+        return f"'{value.isoformat()}'"
+
 
 class Blob(Field):
     type = "BLOB"
@@ -163,6 +192,10 @@ class Blob(Field):
     @staticmethod
     def parse(value: T) -> T:
         return value
+
+    @staticmethod
+    def quote(value: Any) -> str:
+        return str(value)
 
 
 class Boolean(Field):
@@ -177,6 +210,10 @@ class Boolean(Field):
         if isinstance(value, bool):
             return value
         return bool(strtobool(str(value)))
+
+    @staticmethod
+    def quote(value: Any) -> str:
+        return "TRUE" if value else "FALSE"
 
 
 type_map = {

--- a/src/shillelagh/filters.py
+++ b/src/shillelagh/filters.py
@@ -151,8 +151,22 @@ class Range(Filter):
             else:
                 raise Exception(f"Invalid operator: {operator}")
 
-            if (end is not None and new_start is not None and new_start > end) or (
-                start is not None and new_end is not None and new_end < start
+            if (
+                end is not None
+                and new_start is not None
+                and (
+                    new_start > end
+                    or (new_start >= end and (not new_include_start or not include_end))
+                )
+            ):
+                return Impossible()
+            if (
+                start is not None
+                and new_end is not None
+                and (
+                    new_end < start
+                    or (new_end <= start and (not include_start or not new_include_end))
+                )
             ):
                 return Impossible()
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from shillelagh.fields import Blob
 from shillelagh.fields import Boolean
 from shillelagh.fields import Date
@@ -31,6 +32,7 @@ def test_integer():
     assert Integer.parse(1) == 1
     assert Integer.parse("1") == 1
     assert Integer.parse(None) is None
+    assert Integer.quote(1) == "1"
 
 
 def test_blob():
@@ -38,6 +40,7 @@ def test_blob():
     assert Blob.parse("test") == "test"
     assert Blob.parse(b"test") == b"test"
     assert Blob.parse(None) is None
+    assert Blob.quote(1) == "1"
 
 
 def test_date():
@@ -49,6 +52,7 @@ def test_date():
     )
     assert Date.parse(None) is None
     assert Date.parse("invalid") is None
+    assert Date.quote(datetime.date(2020, 1, 1)) == "'2020-01-01'"
 
 
 def test_time():
@@ -64,6 +68,10 @@ def test_time():
     )
     assert Time.parse(None) is None
     assert Time.parse("invalid") is None
+    assert (
+        Time.quote(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
+        == "'12:00:00+00:00'"
+    )
 
 
 def test_datetime():
@@ -78,6 +86,12 @@ def test_datetime():
     )
     assert DateTime.parse(None) is None
     assert DateTime.parse("invalid") is None
+    assert (
+        DateTime.quote(
+            datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+        == "'2020-01-01T12:00:00+00:00'"
+    )
 
 
 def test_boolean():
@@ -85,6 +99,8 @@ def test_boolean():
     assert Boolean.parse(False) is False
     assert Boolean.parse("true") is True
     assert Boolean.parse(0) is False
+    assert Boolean.quote(True) == "TRUE"
+    assert Boolean.quote(False) == "FALSE"
 
 
 def test_type_code():
@@ -98,3 +114,15 @@ def test_type_code():
     assert Boolean == NUMBER
 
     assert not NUMBER == 1
+
+
+def test_quote():
+    assert Integer.quote(1) == "1"
+    assert Float.quote(1.0) == "1.0"
+    assert String.quote("one") == "'one'"
+    assert (
+        DateTime.quote(
+            datetime.datetime(2021, 6, 3, 7, 0, tzinfo=datetime.timezone.utc),
+        )
+        == "'2021-06-03T07:00:00+00:00'"
+    )

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,9 +1,14 @@
 import pytest
+from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
 from shillelagh.fields import Order
 from shillelagh.fields import String
+from shillelagh.filters import Equal
+from shillelagh.filters import Impossible
+from shillelagh.filters import Range
 from shillelagh.lib import analyse
+from shillelagh.lib import build_sql
 from shillelagh.lib import DELETED
 from shillelagh.lib import RowIDManager
 from shillelagh.lib import update_order
@@ -97,3 +102,43 @@ def test_update_order():
 
     order = update_order(order, previous=2, current=1, num_rows=4)
     assert order == Order.NONE
+
+
+def test_build_sql():
+    columns = {"a": String(), "b": Float()}
+
+    sql = build_sql(columns, {"a": Equal("b")}, [])
+    assert sql == "SELECT * WHERE a = 'b'"
+
+    sql = build_sql(columns, {"b": Range(1, 10, False, True)}, [])
+    assert sql == "SELECT * WHERE b > 1 AND b <= 10"
+
+    sql = build_sql(columns, {"b": Range(1, None, True, False)}, [])
+    assert sql == "SELECT * WHERE b >= 1"
+
+    sql = build_sql(columns, {"b": Range(None, 10, True, False)}, [])
+    assert sql == "SELECT * WHERE b < 10"
+
+    sql = build_sql(columns, {}, [])
+    assert sql == "SELECT *"
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        build_sql(columns, {"a": [1, 2, 3]}, [])
+    assert str(excinfo.value) == "Invalid filter: [1, 2, 3]"
+
+
+def test_build_sql_with_map():
+    columns = {f"col{i}_": Integer() for i in range(4)}
+    bounds = {
+        "col0_": Equal(1),
+        "col1_": Range(start=0, end=1, include_start=True, include_end=False),
+        "col2_": Range(start=None, end=1, include_start=False, include_end=True),
+        "col3_": Range(start=0, end=None, include_start=False, include_end=True),
+    }
+    order = [("col0_", Order.ASCENDING), ("col1_", Order.DESCENDING)]
+    column_map = {f"col{i}_": letter for i, letter in enumerate("ABCD")}
+    sql = build_sql(columns, bounds, order, column_map)
+    assert (
+        sql
+        == "SELECT * WHERE A = 1 AND B >= 0 AND B < 1 AND C <= 1 AND D > 0 ORDER BY A, B DESC"
+    )


### PR DESCRIPTION
Writing this for myself...

There's a lot of type conversion — eg, converting a `datetime.datetime` to an ISO string — going on in `shillelagh`.

Adapters need to do type conversion in `get_data`, yielding native Python types. This means that the GSheets adapter needs to convert `Date(2020,0,1)` into `datetime.date(2020, 1, 1)` (months are zero-indexed!).

The `apsw` backend (`shillelagh.backends.apsw.vt`) needs to convert these values into types supported by SQLite. This means converting `datetime.date` back to an ISO string, eg. This is inefficient, but opens the door to more backends in the future (eg, https://multicorn.org/implementing-a-fdw/).

Finally, the `apsw` Python DB API 2 driver needs to convert the SQLite-safe types back to native types, so that the user gets `datetime.datetime` objects if the column is a `TIMESTAMP`, and not a string.

In summary:

Layer | From | To
-- | -- | --
SQLAlchemy dialects | Python native | Python native
`apsw` Python DB API 2 | SQLite types | Python native
`apsw` VT | Python native | SQLite types
Adapter | DB native (eg, `Date(2020,0,1)`) | Python native

This PR changes the conversion of the adapter layer. Adapters can now return DB native types, and the conversion is done using custom fields. This better encapsulates the logic (see changes to the GSheets adapter), and keeps the conversion in the appropriate layer (it's now implemented in the base adapter).

If we ever implement a Postgres FDW adapter the `apsw` logic is somewhat isolated and shouldn't interfere. The DB API 2 conversion still lives in `shillelagh.fields`, and we might want to move them to `shillelagh.backends.apsw` in the future, though.