### PR TITLE
feat: improve type conversion

### DIFF
--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -50,6 +50,11 @@ class Adapter:
     ) -> Iterator[Row]:
         """
         Yield rows as DB-specific types.
+
+        This method expects rows to be in the storage format. Eg, for the CSV adapter
+        datetime columns would be stored (and yielded) as strings. The `get_rows`
+        method will use the adapter fields to convert these values into native Python
+        types (in this case, a proper `datetime.datetime`).
         """
         raise NotImplementedError("Subclasses must implement `get_data`")
 
@@ -71,16 +76,41 @@ class Adapter:
                 for column_name, value in row.items()
             }
 
-    def insert_row(self, row: Row) -> int:
+    def insert_data(self, row: Row) -> int:
         raise NotImplementedError("Subclasses must implement `insert_row`")
 
-    def delete_row(self, row_id: int) -> None:
+    def insert_row(self, row: Row) -> int:
+        """
+        Convert native Python to DB-specific types.
+        """
+        columns = self.get_columns()
+        columns["rowid"] = Integer()
+        row = {
+            column_name: columns[column_name].format(value)
+            for column_name, value in row.items()
+        }
+        return self.insert_data(row)
+
+    def delete_data(self, row_id: int) -> None:
         raise NotImplementedError("Subclasses must implement `delete_row`")
+
+    def delete_row(self, row_id: int) -> None:
+        return self.delete_data(row_id)
+
+    def update_data(self, row_id: int, row: Row) -> None:
+        # Subclasses are free to implement inplace updates
+        self.delete_data(row_id)
+        self.insert_data(row)
 
     def update_row(self, row_id: int, row: Row) -> None:
         # Subclasses are free to implement inplace updates
-        self.delete_row(row_id)
-        self.insert_row(row)
+        columns = self.get_columns()
+        columns["rowid"] = Integer()
+        row = {
+            column_name: columns[column_name].format(value)
+            for column_name, value in row.items()
+        }
+        self.update_data(row_id, row)
 
     def close(self) -> None:
         pass

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -148,24 +148,32 @@ class VTTable:
 
     Destroy = Disconnect
 
-    # TODO: convert to native type?
     def UpdateInsertRow(self, rowid: Optional[int], fields: Tuple[Any, ...]) -> int:
-        column_names = ["rowid"] + list(self.adapter.get_columns().keys())
-        row = dict(zip(column_names, [rowid] + list(fields)))
+        columns = self.adapter.get_columns()
+        row = {
+            column_name: column_field.parse(field)
+            for field, (column_name, column_field) in zip(fields, columns.items())
+        }
+        row["rowid"] = rowid
+
         return cast(int, self.adapter.insert_row(row))
 
     def UpdateDeleteRow(self, rowid: int) -> None:
         self.adapter.delete_row(rowid)
 
-    # TODO: convert to native type?
     def UpdateChangeRow(
         self,
         rowid: int,
         newrowid: int,
         fields: Tuple[Any, ...],
     ) -> None:
-        column_names = ["rowid"] + list(self.adapter.get_columns().keys())
-        row = dict(zip(column_names, [newrowid] + list(fields)))
+        columns = self.adapter.get_columns()
+        row = {
+            column_name: column_field.parse(field)
+            for field, (column_name, column_field) in zip(fields, columns.items())
+        }
+        row["rowid"] = newrowid
+
         self.adapter.update_row(rowid, row)
 
 

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -60,6 +60,13 @@ class Field:
         raise NotImplementedError("Subclasses must implement `parse`")
 
     @staticmethod
+    def format(value: Any) -> Any:
+        if value is None:
+            return None
+
+        return value
+
+    @staticmethod
     def quote(value: Any) -> str:
         raise NotImplementedError("Subclasses must implement `quote`")
 
@@ -133,6 +140,13 @@ class Date(Field):
         return dt.astimezone(datetime.timezone.utc).date()
 
     @staticmethod
+    def format(value: Optional[datetime.date]) -> Optional[str]:
+        if value is None:
+            return None
+
+        return value.isoformat()
+
+    @staticmethod
     def quote(value: Any) -> str:
         return f"'{value.isoformat()}'"
 
@@ -157,6 +171,13 @@ class Time(Field):
         return dt.astimezone(datetime.timezone.utc).timetz()
 
     @staticmethod
+    def format(value: Optional[datetime.date]) -> Optional[str]:
+        if value is None:
+            return None
+
+        return value.isoformat()
+
+    @staticmethod
     def quote(value: Any) -> str:
         return f"'{value.isoformat()}'"
 
@@ -179,6 +200,13 @@ class DateTime(Field):
             dt = dt.replace(tzinfo=datetime.timezone.utc)
 
         return dt.astimezone(datetime.timezone.utc)
+
+    @staticmethod
+    def format(value: Optional[datetime.date]) -> Optional[str]:
+        if value is None:
+            return None
+
+        return value.isoformat()
 
     @staticmethod
     def quote(value: Any) -> str:

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -60,9 +60,11 @@ class FakeAdapter(Adapter):
     ) -> Iterator[Dict[str, Any]]:
         data = self.data[:]
 
-        for column in ["name", "age"]:
-            if column in bounds:
-                data = [row for row in data if bounds[column].check(row[column])]
+        for column_name, field in self.get_columns().items():
+            if field.filters and column_name in bounds:
+                data = [
+                    row for row in data if bounds[column_name].check(row[column_name])
+                ]
 
         for column_name, requested_order in order:
             reverse = requested_order == Order.DESCENDING
@@ -70,16 +72,17 @@ class FakeAdapter(Adapter):
 
         yield from iter(data)
 
-    def insert_row(self, row: Row) -> int:
+    def insert_data(self, row: Row) -> int:
         row_id: Optional[int] = row["rowid"]
         if row_id is None:
-            row["rowid"] = row_id = max(row["rowid"] for row in self.data) + 1
+            max_rowid = max(row["rowid"] for row in self.data) if self.data else 0
+            row["rowid"] = row_id = max_rowid + 1
 
         self.data.append(row)
 
         return row_id
 
-    def delete_row(self, row_id: int) -> None:
+    def delete_data(self, row_id: int) -> None:
         self.data = [row for row in self.data if row["rowid"] != row_id]
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -33,6 +33,8 @@ def test_integer():
     assert Integer.parse("1") == 1
     assert Integer.parse(None) is None
     assert Integer.quote(1) == "1"
+    assert Integer.format(1) == 1
+    assert Integer.format(None) is None
 
 
 def test_float():
@@ -40,6 +42,8 @@ def test_float():
     assert Float.parse("1.0") == 1.0
     assert Float.parse(None) is None
     assert Float.quote(1.0) == "1.0"
+    assert Float.format(1.0) == 1.0
+    assert Float.format(None) is None
 
 
 def test_string():
@@ -48,6 +52,8 @@ def test_string():
     assert String.parse(None) is None
     assert String.quote("1.0") == "'1.0'"
     assert String.quote("O'Malley's") == "'O''Malley''s'"
+    assert String.format("test") == "test"
+    assert String.format(None) is None
 
 
 def test_blob():
@@ -56,6 +62,8 @@ def test_blob():
     assert Blob.parse(b"test") == b"test"
     assert Blob.parse(None) is None
     assert Blob.quote(b"\x00") == "X'00'"
+    assert Blob.format(b"test") == b"test"
+    assert Blob.format(None) is None
 
 
 def test_date():
@@ -68,6 +76,8 @@ def test_date():
     assert Date.parse(None) is None
     assert Date.parse("invalid") is None
     assert Date.quote(datetime.date(2020, 1, 1)) == "'2020-01-01'"
+    assert Date.format(datetime.date(2020, 1, 1)) == "2020-01-01"
+    assert Date.format(None) is None
 
 
 def test_time():
@@ -87,6 +97,11 @@ def test_time():
         Time.quote(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
         == "'12:00:00+00:00'"
     )
+    assert (
+        Time.format(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
+        == "12:00:00+00:00"
+    )
+    assert Time.format(None) is None
 
 
 def test_datetime():
@@ -116,6 +131,13 @@ def test_datetime():
         )
         == "'2020-01-01T12:00:00+00:00'"
     )
+    assert (
+        DateTime.format(
+            datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+        == "2020-01-01T12:00:00+00:00"
+    )
+    assert DateTime.format(None) is None
 
 
 def test_boolean():
@@ -126,6 +148,8 @@ def test_boolean():
     assert Boolean.parse(None) is None
     assert Boolean.quote(True) == "TRUE"
     assert Boolean.quote(False) == "FALSE"
+    assert Boolean.format(True) is True
+    assert Boolean.format(None) is None
 
 
 def test_type_code():


### PR DESCRIPTION
This PR makes the `insert_row` and `update_row` methods in the adapter class compatible with the `get_rows` method. Just like `get_rows` expects rows with native Python types (`datetime`, eg), the DML functions should also receive native types. This means that the types need to be converted to the DB-native format before being passed to the adapter, in order to simplify the adapter.