### PR TITLE
fix: row ID manager without rows

### DIFF
--- a/src/shillelagh/filters.py
+++ b/src/shillelagh/filters.py
@@ -51,6 +51,9 @@ class Equal(Filter):
     def check(self, value: Any) -> bool:
         return bool(value == self.value)
 
+    def __repr__(self) -> str:
+        return f"== {self.value}"
+
 
 class Range(Filter):
     def __init__(
@@ -203,3 +206,16 @@ class Range(Filter):
                 return False
 
         return True
+
+    def __repr__(self) -> str:
+        if self.start == self.end and self.include_start and self.include_end:
+            return f"== {self.start}"
+
+        comparisons = []
+        if self.start is not None:
+            op = ">=" if self.include_start else ">"
+            comparisons.append(f"{op}{self.start}")
+        if self.end is not None:
+            op = "<=" if self.include_end else "<"
+            comparisons.append(f"{op}{self.end}")
+        return ",".join(comparisons)

--- a/src/shillelagh/lib.py
+++ b/src/shillelagh/lib.py
@@ -88,6 +88,7 @@ def analyse(
     types: Dict[str, Type[Field]] = {}
 
     previous_row: Optional[Row] = None
+    i = 0
     for i, row in enumerate(data):
         for column_name, value in row.items():
             # determine order


### PR DESCRIPTION
Add a `__repr__` to filters and fix a small bug in the row ID manager that should never happen.