### PR TITLE
feat: DML for Google Sheets

### DIFF
--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -68,7 +68,7 @@ class Adapter:
         """
         columns = self.get_columns()
         parsers = {column_name: field.parse for column_name, field in columns.items()}
-        parsers["rowid"] = Integer.parse
+        parsers["rowid"] = Integer().parse
 
         for row in self.get_data(bounds, order):
             yield {
@@ -83,7 +83,7 @@ class Adapter:
         """
         Convert native Python to DB-specific types.
         """
-        columns = self.get_columns()
+        columns = self.get_columns().copy()
         columns["rowid"] = Integer()
         row = {
             column_name: columns[column_name].format(value)
@@ -104,7 +104,7 @@ class Adapter:
 
     def update_row(self, row_id: int, row: Row) -> None:
         # Subclasses are free to implement inplace updates
-        columns = self.get_columns()
+        columns = self.get_columns().copy()
         columns["rowid"] = Integer()
         row = {
             column_name: columns[column_name].format(value)

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -182,7 +182,7 @@ class Cursor(object):
         for row in cursor:
             yield tuple(
                 # convert from SQLite types to native Python types
-                type_map[desc[1].type].parse(col)
+                type_map[desc[1].type]().parse(col)
                 for col, desc in zip(row, self.description)
             )
 

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -53,7 +53,7 @@ def convert_rows_to_sqlite(
     the conversion (not the adapter fields).
     """
     converters = {
-        column_name: type_map[column_field.type].format
+        column_name: type_map[column_field.type]().format
         for column_name, column_field in columns.items()
     }
     converters["rowid"] = Integer().format
@@ -76,7 +76,7 @@ def convert_rows_from_sqlite(
     the conversion (not the adapter fields).
     """
     converters = {
-        column_name: type_map[column_field.type].parse
+        column_name: type_map[column_field.type]().parse
         for column_name, column_field in columns.items()
     }
     converters["rowid"] = Integer().parse
@@ -232,7 +232,7 @@ class VTCursor:
             column_type = columns[column_name]
 
             # convert constraint to native Python type, then to DB specific type
-            constraint = type_map[column_type.type].parse(constraint)
+            constraint = type_map[column_type.type]().parse(constraint)
             value = column_type.format(constraint)
 
             all_bounds[column_name].add((operator, value))

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -62,8 +62,7 @@ class Field:
             and self.exact == other.exact
         )
 
-    @staticmethod
-    def parse(value: Any) -> Any:
+    def parse(self, value: Any) -> Any:
         """
         Convert from a DB type to a native Python type.
 
@@ -83,8 +82,7 @@ class Field:
         """
         raise NotImplementedError("Subclasses must implement `parse`")
 
-    @staticmethod
-    def format(value: Any) -> Any:
+    def format(self, value: Any) -> Any:
         """
         Convert from a native Python type to a DB type.
 
@@ -92,8 +90,7 @@ class Field:
         """
         raise NotImplementedError("Subclasses must implement `format`")
 
-    @staticmethod
-    def quote(value: Any) -> str:
+    def quote(self, value: Any) -> str:
         """
         Quote values.
 
@@ -113,8 +110,7 @@ class Integer(Field):
     type = "INTEGER"
     db_api_type = "NUMBER"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[int]:
+    def parse(self, value: Any) -> Optional[int]:
         if value is None:
             return None
 
@@ -122,8 +118,7 @@ class Integer(Field):
 
     format = parse
 
-    @staticmethod
-    def quote(value: Any) -> str:
+    def quote(self, value: Any) -> str:
         return str(value)
 
 
@@ -131,8 +126,7 @@ class Float(Field):
     type = "REAL"
     db_api_type = "NUMBER"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[float]:
+    def parse(self, value: Any) -> Optional[float]:
         if value is None:
             return None
 
@@ -140,8 +134,7 @@ class Float(Field):
 
     format = parse
 
-    @staticmethod
-    def quote(value: Any) -> str:
+    def quote(self, value: Any) -> str:
         return str(value)
 
 
@@ -149,8 +142,7 @@ class String(Field):
     type = "TEXT"
     db_api_type = "STRING"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[str]:
+    def parse(self, value: Any) -> Optional[str]:
         if value is None:
             return None
 
@@ -158,8 +150,7 @@ class String(Field):
 
     format = parse
 
-    @staticmethod
-    def quote(value: Any) -> str:
+    def quote(self, value: Any) -> str:
         escaped_value = value.replace("'", "''")
         return f"'{escaped_value}'"
 
@@ -168,8 +159,7 @@ class Date(Field):
     type = "DATE"
     db_api_type = "DATETIME"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[datetime.date]:
+    def parse(self, value: Any) -> Optional[datetime.date]:
         if value is None:
             return None
 
@@ -183,25 +173,21 @@ class Date(Field):
 
         return dt.astimezone(datetime.timezone.utc).date()
 
-    @staticmethod
-    def format(value: Optional[datetime.date]) -> Optional[str]:
+    def format(self, value: Optional[datetime.date]) -> Optional[str]:
         if value is None:
             return None
 
         return value.isoformat()
 
-    @staticmethod
-    def quote(value: Any) -> str:
-        formatted_value = Date.format(value)
-        return f"'{formatted_value}'"
+    def quote(self, value: Any) -> str:
+        return f"'{self.format(value)}'"
 
 
 class Time(Field):
     type = "TIME"
     db_api_type = "DATETIME"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[datetime.time]:
+    def parse(self, value: Any) -> Optional[datetime.time]:
         if value is None:
             return None
 
@@ -215,25 +201,21 @@ class Time(Field):
 
         return dt.astimezone(datetime.timezone.utc).timetz()
 
-    @staticmethod
-    def format(value: Optional[datetime.date]) -> Optional[str]:
+    def format(self, value: Optional[datetime.time]) -> Optional[str]:
         if value is None:
             return None
 
         return value.isoformat()
 
-    @staticmethod
-    def quote(value: Any) -> str:
-        formatted_value = Time.format(value)
-        return f"'{formatted_value}'"
+    def quote(self, value: Any) -> str:
+        return f"'{self.format(value)}'"
 
 
 class DateTime(Field):
     type = "TIMESTAMP"
     db_api_type = "DATETIME"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[datetime.datetime]:
+    def parse(self, value: Any) -> Optional[datetime.datetime]:
         if value is None:
             return None
 
@@ -247,25 +229,21 @@ class DateTime(Field):
 
         return dt.astimezone(datetime.timezone.utc)
 
-    @staticmethod
-    def format(value: Optional[datetime.date]) -> Optional[str]:
+    def format(self, value: Optional[datetime.datetime]) -> Optional[str]:
         if value is None:
             return None
 
         return value.isoformat()
 
-    @staticmethod
-    def quote(value: Any) -> str:
-        formatted_value = DateTime.format(value)
-        return f"'{formatted_value}'"
+    def quote(self, value: Any) -> str:
+        return f"'{self.format(value)}'"
 
 
 class Blob(Field):
     type = "BLOB"
     db_api_type = "BINARY"
 
-    @staticmethod
-    def parse(value: Any) -> Any:
+    def parse(self, value: Any) -> Any:
         if value is None:
             return None
 
@@ -274,8 +252,7 @@ class Blob(Field):
         except Exception:
             return value
 
-    @staticmethod
-    def format(value: Any) -> Optional[str]:
+    def format(self, value: Any) -> Optional[str]:
         if value is None:
             return None
 
@@ -284,18 +261,15 @@ class Blob(Field):
 
         return cast(str, value.hex())
 
-    @staticmethod
-    def quote(value: bytes) -> str:
-        formatted_value = Blob.format(value)
-        return f"X'{formatted_value}'"
+    def quote(self, value: bytes) -> str:
+        return f"X'{self.format(value)}'"
 
 
 class Boolean(Field):
     type = "BOOLEAN"
     db_api_type = "NUMBER"
 
-    @staticmethod
-    def parse(value: Any) -> Optional[bool]:
+    def parse(self, value: Any) -> Optional[bool]:
         if value is None:
             return None
 
@@ -303,16 +277,14 @@ class Boolean(Field):
             return value
         return bool(strtobool(str(value)))
 
-    @staticmethod
-    def format(value: Optional[bool]) -> Optional[str]:
+    def format(self, value: Optional[bool]) -> Optional[str]:
         if value is None:
             return None
 
         return "TRUE" if value else "FALSE"
 
-    @staticmethod
-    def quote(value: Any) -> str:
-        return cast(str, Boolean.format(value))
+    def quote(self, value: Any) -> str:
+        return cast(str, self.format(value))
 
 
 type_map = {

--- a/tests/adapters/api/test_gsheets.py
+++ b/tests/adapters/api/test_gsheets.py
@@ -643,9 +643,13 @@ def test_get_session(mocker):
         return_value=None,
     )
 
-    # prevent network call
+    # prevent network calls
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._set_columns",
+        mock.MagicMock(),
+    )
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._set_metadata",
         mock.MagicMock(),
     )
 
@@ -1287,7 +1291,7 @@ def test_delete_data(mocker, simple_sheet_adapter):
                 "code": 404,
                 "message": "Requested entity was not found.",
                 "status": "NOT_FOUND",
-            }
+            },
         },
     )
     with pytest.raises(ProgrammingError) as excinfo:
@@ -1302,7 +1306,7 @@ def test_delete_data(mocker, simple_sheet_adapter):
                 "code": 404,
                 "message": "Requested entity was not found.",
                 "status": "NOT_FOUND",
-            }
+            },
         },
     )
     with pytest.raises(ProgrammingError) as excinfo:

--- a/tests/adapters/api/test_gsheets.py
+++ b/tests/adapters/api/test_gsheets.py
@@ -3,6 +3,7 @@ import json
 from unittest import mock
 
 import apsw
+import dateutil.tz
 import pytest
 import requests
 import requests_mock
@@ -26,6 +27,98 @@ from shillelagh.filters import Range
 
 from ...fakes import FakeAdapter
 from ...fakes import FakeEntryPoint
+
+
+@pytest.fixture
+def simple_sheet_adapter():
+    adapter = requests_mock.Adapter()
+    adapter.register_uri(
+        "GET",
+        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A%20LIMIT%201",
+        json={
+            "version": "0.6",
+            "reqId": "0",
+            "status": "ok",
+            "sig": "1453301915",
+            "table": {
+                "cols": [
+                    {"id": "A", "label": "country", "type": "string"},
+                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
+                ],
+                "rows": [{"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]}],
+                "parsedNumHeaders": 0,
+            },
+        },
+    )
+    adapter.register_uri(
+        "GET",
+        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A",
+        json={
+            "version": "0.6",
+            "reqId": "0",
+            "status": "ok",
+            "sig": "1642441872",
+            "table": {
+                "cols": [
+                    {"id": "A", "label": "country", "type": "string"},
+                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
+                ],
+                "rows": [
+                    {"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]},
+                    {"c": [{"v": "BR"}, {"v": 3.0, "f": "3"}]},
+                    {"c": [{"v": "IN"}, {"v": 5.0, "f": "5"}]},
+                    {"c": [{"v": "ZA"}, {"v": 6.0, "f": "6"}]},
+                    {"c": [{"v": "CR"}, {"v": 10.0, "f": "10"}]},
+                ],
+                "parsedNumHeaders": 1,
+            },
+        },
+    )
+    adapter.register_uri(
+        "GET",
+        "https://sheets.googleapis.com/v4/spreadsheets/1?includeGridData=false",
+        json={
+            "spreadsheetId": "1",
+            "properties": {
+                "title": "Sheet1",
+                "locale": "en_US",
+                "autoRecalc": "ON_CHANGE",
+                "timeZone": "America/Los_Angeles",
+                "defaultFormat": {
+                    "backgroundColor": {"red": 1, "green": 1, "blue": 1},
+                    "padding": {"top": 2, "right": 3, "bottom": 2, "left": 3},
+                    "verticalAlignment": "BOTTOM",
+                    "wrapStrategy": "OVERFLOW_CELL",
+                    "textFormat": {
+                        "foregroundColor": {},
+                        "fontFamily": "arial,sans,sans-serif",
+                        "fontSize": 10,
+                        "bold": False,
+                        "italic": False,
+                        "strikethrough": False,
+                        "underline": False,
+                        "foregroundColorStyle": {"rgbColor": {}},
+                    },
+                    "backgroundColorStyle": {
+                        "rgbColor": {"red": 1, "green": 1, "blue": 1},
+                    },
+                },
+            },
+            "sheets": [
+                {
+                    "properties": {
+                        "sheetId": 0,
+                        "title": "Sheet1",
+                        "index": 0,
+                        "sheetType": "GRID",
+                        "gridProperties": {"rowCount": 985, "columnCount": 26},
+                    },
+                },
+            ],
+            "spreadsheetUrl": "https://docs.google.com/spreadsheets/d/1/edit?ouid=111430789371895352716&urlBuilderDomain=dealmeida.net",
+        },
+    )
+    yield adapter
 
 
 def test_credentials(mocker):
@@ -94,7 +187,11 @@ def test_get_credentials(mocker):
     credentials.assert_not_called()
     service_account.from_service_account_file.assert_called_with(
         "credentials.json",
-        scopes=["https://www.googleapis.com/auth/drive.readonly"],
+        scopes=[
+            "https://www.googleapis.com/auth/drive.readonly",
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://spreadsheets.google.com/feeds",
+        ],
         subject=None,
     )
     service_account.reset_mock()
@@ -104,66 +201,27 @@ def test_get_credentials(mocker):
     credentials.assert_not_called()
     service_account.from_service_account_info.assert_called_with(
         {"secret": "XXX"},
-        scopes=["https://www.googleapis.com/auth/drive.readonly"],
+        scopes=[
+            "https://www.googleapis.com/auth/drive.readonly",
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://spreadsheets.google.com/feeds",
+        ],
         subject="user@example.com",
     )
 
 
-def test_execute(mocker):
+def test_execute(mocker, simple_sheet_adapter):
     entry_points = [FakeEntryPoint("gsheetsapi", GSheetsAPI)]
     mocker.patch(
         "shillelagh.backends.apsw.db.iter_entry_points",
         return_value=entry_points,
     )
 
-    adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/1", adapter)
+    session.mount("https://", simple_sheet_adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
-    )
-    adapter.register_uri(
-        "GET",
-        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A%20LIMIT%201",
-        json={
-            "version": "0.6",
-            "reqId": "0",
-            "status": "ok",
-            "sig": "1453301915",
-            "table": {
-                "cols": [
-                    {"id": "A", "label": "country", "type": "string"},
-                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
-                ],
-                "rows": [{"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]}],
-                "parsedNumHeaders": 0,
-            },
-        },
-    )
-    adapter.register_uri(
-        "GET",
-        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A",
-        json={
-            "version": "0.6",
-            "reqId": "0",
-            "status": "ok",
-            "sig": "1642441872",
-            "table": {
-                "cols": [
-                    {"id": "A", "label": "country", "type": "string"},
-                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
-                ],
-                "rows": [
-                    {"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]},
-                    {"c": [{"v": "BR"}, {"v": 3.0, "f": "3"}]},
-                    {"c": [{"v": "IN"}, {"v": 5.0, "f": "5"}]},
-                    {"c": [{"v": "ZA"}, {"v": 6.0, "f": "6"}]},
-                    {"c": [{"v": "CR"}, {"v": 10.0, "f": "10"}]},
-                ],
-                "parsedNumHeaders": 1,
-            },
-        },
     )
 
     connection = connect(":memory:", ["gsheetsapi"])
@@ -180,39 +238,20 @@ def test_execute(mocker):
     ]
 
 
-def test_execute_filter(mocker):
+def test_execute_filter(mocker, simple_sheet_adapter):
     entry_points = [FakeEntryPoint("gsheetsapi", GSheetsAPI)]
     mocker.patch(
         "shillelagh.backends.apsw.db.iter_entry_points",
         return_value=entry_points,
     )
 
-    adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/1", adapter)
+    session.mount("https://", simple_sheet_adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
     )
-    adapter.register_uri(
-        "GET",
-        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A%20LIMIT%201",
-        json={
-            "version": "0.6",
-            "reqId": "0",
-            "status": "ok",
-            "sig": "1453301915",
-            "table": {
-                "cols": [
-                    {"id": "A", "label": "country", "type": "string"},
-                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
-                ],
-                "rows": [{"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]}],
-                "parsedNumHeaders": 0,
-            },
-        },
-    )
-    adapter.register_uri(
+    simple_sheet_adapter.register_uri(
         "GET",
         "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A%20WHERE%20B%20%3C%205.0",
         json={
@@ -248,37 +287,18 @@ def test_execute_filter(mocker):
     ]
 
 
-def test_execute_impossible(mocker):
+def test_execute_impossible(mocker, simple_sheet_adapter):
     entry_points = [FakeEntryPoint("gsheetsapi", GSheetsAPI)]
     mocker.patch(
         "shillelagh.backends.apsw.db.iter_entry_points",
         return_value=entry_points,
     )
 
-    adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/1", adapter)
+    session.mount("https://", simple_sheet_adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
-    )
-    adapter.register_uri(
-        "GET",
-        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A%20LIMIT%201",
-        json={
-            "version": "0.6",
-            "reqId": "0",
-            "status": "ok",
-            "sig": "1453301915",
-            "table": {
-                "cols": [
-                    {"id": "A", "label": "country", "type": "string"},
-                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
-                ],
-                "rows": [{"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]}],
-                "parsedNumHeaders": 0,
-            },
-        },
     )
 
     connection = connect(":memory:", ["gsheetsapi"])
@@ -347,7 +367,7 @@ def test_convert_rows(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/2", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -629,8 +649,8 @@ def test_get_session(mocker):
         mock.MagicMock(),
     )
 
-    adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1")
-    adapter._get_session()
+    gsheets_adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1")
+    gsheets_adapter._get_session()
     mock_authorized_session.assert_not_called()
     mock_session.assert_called()
 
@@ -641,13 +661,13 @@ def test_get_session(mocker):
         "shillelagh.adapters.api.gsheets.get_credentials",
         return_value="SECRET",
     )
-    adapter = GSheetsAPI(
+    gsheets_adapter = GSheetsAPI(
         "https://docs.google.com/spreadsheets/d/1",
         service_account_info={"secret": "XXX"},
         subject="user@example.com",
     )
-    assert adapter.credentials == "SECRET"
-    adapter._get_session()
+    assert gsheets_adapter.credentials == "SECRET"
+    gsheets_adapter._get_session()
     mock_authorized_session.assert_called()
     mock_session.assert_not_called()
 
@@ -661,7 +681,7 @@ def test_api_bugs(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/3", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -728,41 +748,22 @@ def test_api_bugs(mocker):
     )
 
 
-def test_execute_json_prefix(mocker):
+def test_execute_json_prefix(mocker, simple_sheet_adapter):
     entry_points = [FakeEntryPoint("gsheetsapi", GSheetsAPI)]
     mocker.patch(
         "shillelagh.backends.apsw.db.iter_entry_points",
         return_value=entry_points,
     )
 
-    adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/4", adapter)
+    session.mount("https://", simple_sheet_adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
     )
-    adapter.register_uri(
+    simple_sheet_adapter.register_uri(
         "GET",
-        "https://docs.google.com/spreadsheets/d/4/gviz/tq?gid=0&tq=SELECT%20%2A%20LIMIT%201",
-        json={
-            "version": "0.6",
-            "reqId": "0",
-            "status": "ok",
-            "sig": "2050160589",
-            "table": {
-                "cols": [
-                    {"id": "A", "label": "country", "type": "string"},
-                    {"id": "B", "label": "cnt", "type": "number", "pattern": "General"},
-                ],
-                "rows": [{"c": [{"v": "BR"}, {"v": 1.0, "f": "1"}]}],
-                "parsedNumHeaders": 0,
-            },
-        },
-    )
-    adapter.register_uri(
-        "GET",
-        "https://docs.google.com/spreadsheets/d/4/gviz/tq?gid=0&tq=SELECT%20%2A",
+        "https://docs.google.com/spreadsheets/d/1/gviz/tq?gid=0&tq=SELECT%20%2A",
         text=")]}'\n"
         + json.dumps(
             {
@@ -796,7 +797,7 @@ def test_execute_json_prefix(mocker):
     connection = connect(":memory:", ["gsheetsapi"])
     cursor = connection.cursor()
 
-    sql = '''SELECT * FROM "https://docs.google.com/spreadsheets/d/4/edit#gid=0"'''
+    sql = '''SELECT * FROM "https://docs.google.com/spreadsheets/d/1/edit#gid=0"'''
     data = list(cursor.execute(sql))
     assert data == [
         ("BR", 1),
@@ -816,7 +817,7 @@ def test_execute_invalid_json(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/5", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -848,7 +849,7 @@ def test_execute_error_response(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/6", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -888,7 +889,7 @@ def test_headers_not_detected(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/7", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -959,7 +960,7 @@ def test_headers_not_detected_no_rows(mocker):
 
     adapter = requests_mock.Adapter()
     session = requests.Session()
-    session.mount("https://docs.google.com/spreadsheets/d/8", adapter)
+    session.mount("https://", adapter)
     mocker.patch(
         "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
         return_value=session,
@@ -1015,39 +1016,295 @@ def test_headers_not_detected_no_rows(mocker):
 
 
 def test_fields():
-    assert GSheetsDateTime.parse(None) is None
-    assert GSheetsDateTime.parse("Date(2018,8,9,0,0,0)") == datetime.datetime(
+    assert GSheetsDateTime().parse(None) is None
+    assert GSheetsDateTime().parse("Date(2018,8,9,0,0,0)") == datetime.datetime(
         2018,
         9,
         9,
         0,
         0,
-        tzinfo=datetime.timezone.utc,
     )
     assert (
-        GSheetsDateTime.quote(
+        GSheetsDateTime().quote(
             datetime.datetime(2018, 9, 9, 0, 0, tzinfo=datetime.timezone.utc),
         )
         == "datetime '2018-09-09 00:00:00+00:00'"
     )
 
-    assert GSheetsDate.parse(None) is None
-    assert GSheetsDate.parse("Date(2018,0,1)") == datetime.date(2018, 1, 1)
-    assert GSheetsDate.quote(datetime.date(2018, 1, 1)) == "date '2018-01-01'"
+    assert GSheetsDate().parse(None) is None
+    assert GSheetsDate().parse("Date(2018,0,1)") == datetime.date(2018, 1, 1)
+    assert GSheetsDate().quote(datetime.date(2018, 1, 1)) == "date '2018-01-01'"
 
-    assert GSheetsTime.parse(None) is None
-    assert GSheetsTime.parse([17, 0, 0, 0]) == datetime.time(
+    assert GSheetsTime().parse(None) is None
+    assert GSheetsTime().parse([17, 0, 0, 0]) == datetime.time(
         17,
         0,
-        tzinfo=datetime.timezone.utc,
     )
     assert (
-        GSheetsTime.quote(datetime.time(17, 0, tzinfo=datetime.timezone.utc))
+        GSheetsTime().quote(datetime.time(17, 0, tzinfo=datetime.timezone.utc))
         == "timeofday '17:00:00+00:00'"
     )
 
-    assert GSheetsBoolean.parse(None) is None
-    assert GSheetsBoolean.parse("TRUE")
-    assert not GSheetsBoolean.parse("FALSE")
-    assert GSheetsBoolean.quote(True) == "true"
-    assert GSheetsBoolean.quote(False) == "false"
+    assert GSheetsBoolean().parse(None) is None
+    assert GSheetsBoolean().parse("TRUE")
+    assert not GSheetsBoolean().parse("FALSE")
+    assert GSheetsBoolean().quote(True) == "true"
+    assert GSheetsBoolean().quote(False) == "false"
+
+    assert GSheetsDateTime().format(None) is None
+    assert (
+        GSheetsDateTime().format(
+            datetime.datetime(2018, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+        == "01/01/2018 00:00:00"
+    )
+    tz = dateutil.tz.gettz("America/Los_Angeles")
+    assert (
+        GSheetsDateTime(timezone=tz).format(
+            datetime.datetime(2018, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+        == "12/31/2017 16:00:00"
+    )
+
+
+def test_set_metadata(mocker, simple_sheet_adapter):
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._set_columns",
+    )
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.get_credentials",
+        return_value="SECRET",
+    )
+
+    session = requests.Session()
+    session.mount("https://", simple_sheet_adapter)
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
+        return_value=session,
+    )
+
+    gsheets_adapter = GSheetsAPI(
+        "https://docs.google.com/spreadsheets/d/1/edit#gid=0",
+        "XXX",
+    )
+    assert gsheets_adapter._spreadsheet_id == "1"
+    assert gsheets_adapter._sheet_id == 0
+    assert gsheets_adapter._sheet_name == "Sheet1"
+    assert gsheets_adapter._timezone == dateutil.tz.gettz("America/Los_Angeles")
+
+    gsheets_adapter = GSheetsAPI(
+        "https://docs.google.com/spreadsheets/d/1/edit?gid=0",
+        "XXX",
+    )
+    assert gsheets_adapter._sheet_id == 0
+    assert gsheets_adapter._sheet_name == "Sheet1"
+
+    _logger = mocker.patch("shillelagh.adapters.api.gsheets._logger")
+    gsheets_adapter = GSheetsAPI(
+        "https://docs.google.com/spreadsheets/d/1/edit#gid=43",
+        "XXX",
+    )
+    assert gsheets_adapter._sheet_name is None
+    _logger.warning.assert_called_with("Could not determine sheet name!")
+
+
+def test_set_metadata_error(mocker):
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._set_columns",
+    )
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.get_credentials",
+        return_value="SECRET",
+    )
+
+    adapter = requests_mock.Adapter()
+    session = requests.Session()
+    session.mount("https://", adapter)
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
+        return_value=session,
+    )
+    adapter.register_uri(
+        "GET",
+        "https://sheets.googleapis.com/v4/spreadsheets/1?includeGridData=false",
+        json={
+            "error": {
+                "code": 404,
+                "message": "Requested entity was not found.",
+                "status": "NOT_FOUND",
+            },
+        },
+    )
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        GSheetsAPI(
+            "https://docs.google.com/spreadsheets/d/1/edit#gid=42",
+            "XXX",
+        )
+    assert str(excinfo.value) == "Requested entity was not found."
+
+
+def test_insert_data(mocker, simple_sheet_adapter):
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.get_credentials",
+        return_value="SECRET",
+    )
+
+    session = requests.Session()
+    session.mount("https://", simple_sheet_adapter)
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
+        return_value=session,
+    )
+    simple_sheet_adapter.register_uri(
+        "POST",
+        "https://sheets.googleapis.com/v4/spreadsheets/1/values/Sheet1:append?valueInputOption=USER_ENTERED",
+        json={
+            "spreadsheetId": "1",
+            "tableRange": "'Sheet1'!A1:F10",
+            "updates": {
+                "spreadsheetId": "1",
+                "updatedRange": "'Sheet1!A11",
+                "updatedRows": 1,
+                "updatedColumns": 1,
+                "updatedCells": 1,
+            },
+        },
+    )
+
+    gsheets_adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1/edit", "XXX")
+
+    row_id = gsheets_adapter.insert_row({"country": "UK", "cnt": 10, "rowid": None})
+    assert row_id == 0
+    assert gsheets_adapter.row_ids == {0: {"cnt": 10.0, "country": "UK"}}
+    assert simple_sheet_adapter.last_request.json() == {
+        "range": "Sheet1",
+        "majorDimension": "ROWS",
+        "values": [["UK", 10.0]],
+    }
+
+    row_id = gsheets_adapter.insert_row({"country": "PY", "cnt": 11, "rowid": 3})
+    assert row_id == 3
+    assert gsheets_adapter.row_ids == {
+        0: {"cnt": 10.0, "country": "UK"},
+        3: {"cnt": 11.0, "country": "PY"},
+    }
+
+    simple_sheet_adapter.register_uri(
+        "POST",
+        "https://sheets.googleapis.com/v4/spreadsheets/1/values/Sheet1:append?valueInputOption=USER_ENTERED",
+        json={
+            "error": {
+                "code": 400,
+                "message": "Request range[WRONG] does not match value's range[Sheet1]",
+                "status": "INVALID_ARGUMENT",
+            },
+        },
+    )
+    with pytest.raises(ProgrammingError) as excinfo:
+        gsheets_adapter.insert_row({"country": "PY", "cnt": 11, "rowid": 3})
+    assert (
+        str(excinfo.value)
+        == "Request range[WRONG] does not match value's range[Sheet1]"
+    )
+
+
+def test_delete_data(mocker, simple_sheet_adapter):
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.get_credentials",
+        return_value="SECRET",
+    )
+
+    session = requests.Session()
+    session.mount("https://", simple_sheet_adapter)
+    mocker.patch(
+        "shillelagh.adapters.api.gsheets.GSheetsAPI._get_session",
+        return_value=session,
+    )
+    simple_sheet_adapter.register_uri(
+        "GET",
+        "https://sheets.googleapis.com/v4/spreadsheets/1/values/Sheet1?valueRenderOption=UNFORMATTED_VALUE",
+        json={
+            "range": "'Sheet1'!A1:Z983",
+            "majorDimension": "ROWS",
+            "values": [
+                ["country", "cnt"],
+                ["BR", 1],
+                ["BR", 3],
+                ["IN", 5],
+                ["ZA", 6],
+                ["UK", 10],
+                ["PY", 11],
+            ],
+        },
+    )
+    simple_sheet_adapter.register_uri(
+        "POST",
+        "https://sheets.googleapis.com/v4/spreadsheets/1:batchUpdate",
+        json={"spreadsheetId": "1", "replies": [{}]},
+    )
+
+    gsheets_adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1/edit", "XXX")
+    gsheets_adapter.row_ids = {
+        0: {"cnt": 10.0, "country": "UK"},
+        3: {"cnt": 11.0, "country": "PY"},
+        4: {"cnt": 12.0, "country": "PL"},
+    }
+
+    gsheets_adapter.delete_row(0)
+    assert gsheets_adapter.row_ids == {
+        3: {"cnt": 11.0, "country": "PY"},
+        4: {"cnt": 12.0, "country": "PL"},
+    }
+    assert simple_sheet_adapter.last_request.json() == {
+        "requests": [
+            {
+                "deleteDimension": {
+                    "range": {
+                        "sheetId": 0,
+                        "dimension": "ROWS",
+                        "startIndex": 5,
+                        "endIndex": 6,
+                    },
+                },
+            },
+        ],
+    }
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        gsheets_adapter.delete_row(4)
+    assert str(excinfo.value) == "Could not find row: {'cnt': 12.0, 'country': 'PL'}"
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        gsheets_adapter.delete_row(5)
+    assert str(excinfo.value) == "Invalid row to delete: 5"
+
+    simple_sheet_adapter.register_uri(
+        "POST",
+        "https://sheets.googleapis.com/v4/spreadsheets/1:batchUpdate",
+        json={
+            "error": {
+                "code": 404,
+                "message": "Requested entity was not found.",
+                "status": "NOT_FOUND",
+            }
+        },
+    )
+    with pytest.raises(ProgrammingError) as excinfo:
+        gsheets_adapter.delete_row(3)
+    assert str(excinfo.value) == "Requested entity was not found."
+
+    simple_sheet_adapter.register_uri(
+        "GET",
+        "https://sheets.googleapis.com/v4/spreadsheets/1/values/Sheet1?valueRenderOption=UNFORMATTED_VALUE",
+        json={
+            "error": {
+                "code": 404,
+                "message": "Requested entity was not found.",
+                "status": "NOT_FOUND",
+            }
+        },
+    )
+    with pytest.raises(ProgrammingError) as excinfo:
+        gsheets_adapter.delete_row(3)
+    assert str(excinfo.value) == "Requested entity was not found."

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -29,85 +29,85 @@ def test_comparison():
 
 
 def test_integer():
-    assert Integer.parse(1) == 1
-    assert Integer.parse("1") == 1
-    assert Integer.parse(None) is None
-    assert Integer.quote(1) == "1"
-    assert Integer.format(1) == 1
-    assert Integer.format(None) is None
+    assert Integer().parse(1) == 1
+    assert Integer().parse("1") == 1
+    assert Integer().parse(None) is None
+    assert Integer().quote(1) == "1"
+    assert Integer().format(1) == 1
+    assert Integer().format(None) is None
 
 
 def test_float():
-    assert Float.parse(1.0) == 1.0
-    assert Float.parse("1.0") == 1.0
-    assert Float.parse(None) is None
-    assert Float.quote(1.0) == "1.0"
-    assert Float.format(1.0) == 1.0
-    assert Float.format(None) is None
+    assert Float().parse(1.0) == 1.0
+    assert Float().parse("1.0") == 1.0
+    assert Float().parse(None) is None
+    assert Float().quote(1.0) == "1.0"
+    assert Float().format(1.0) == 1.0
+    assert Float().format(None) is None
 
 
 def test_string():
-    assert String.parse(1.0) == "1.0"
-    assert String.parse("1.0") == "1.0"
-    assert String.parse(None) is None
-    assert String.quote("1.0") == "'1.0'"
-    assert String.quote("O'Malley's") == "'O''Malley''s'"
-    assert String.format("test") == "test"
-    assert String.format(None) is None
+    assert String().parse(1.0) == "1.0"
+    assert String().parse("1.0") == "1.0"
+    assert String().parse(None) is None
+    assert String().quote("1.0") == "'1.0'"
+    assert String().quote("O'Malley's") == "'O''Malley''s'"
+    assert String().format("test") == "test"
+    assert String().format(None) is None
 
 
 def test_blob():
-    assert Blob.parse(1) == 1
-    assert Blob.parse("test") == "test"
-    assert Blob.parse(b"test") == b"test"
-    assert Blob.parse(None) is None
-    assert Blob.quote(b"\x00") == "X'00'"
-    assert Blob.format(b"test") == "74657374"
-    assert Blob.format(None) is None
-    assert Blob.format("test") == "74657374"
-    assert Blob.format(1) == "31"
+    assert Blob().parse(1) == 1
+    assert Blob().parse("test") == "test"
+    assert Blob().parse(b"test") == b"test"
+    assert Blob().parse(None) is None
+    assert Blob().quote(b"\x00") == "X'00'"
+    assert Blob().format(b"test") == "74657374"
+    assert Blob().format(None) is None
+    assert Blob().format("test") == "74657374"
+    assert Blob().format(1) == "31"
 
 
 def test_date():
-    assert Date.parse("2020-01-01") == datetime.date(2020, 1, 1)
-    assert Date.parse("2020-01-01T00:00+00:00") == datetime.date(
+    assert Date().parse("2020-01-01") == datetime.date(2020, 1, 1)
+    assert Date().parse("2020-01-01T00:00+00:00") == datetime.date(
         2020,
         1,
         1,
     )
-    assert Date.parse(None) is None
-    assert Date.parse("invalid") is None
-    assert Date.quote(datetime.date(2020, 1, 1)) == "'2020-01-01'"
-    assert Date.format(datetime.date(2020, 1, 1)) == "2020-01-01"
-    assert Date.format(None) is None
+    assert Date().parse(None) is None
+    assert Date().parse("invalid") is None
+    assert Date().quote(datetime.date(2020, 1, 1)) == "'2020-01-01'"
+    assert Date().format(datetime.date(2020, 1, 1)) == "2020-01-01"
+    assert Date().format(None) is None
 
 
 def test_time():
-    assert Time.parse("12:00+00:00") == datetime.time(
+    assert Time().parse("12:00+00:00") == datetime.time(
         12,
         0,
         tzinfo=datetime.timezone.utc,
     )
-    assert Time.parse("12:00") == datetime.time(
+    assert Time().parse("12:00") == datetime.time(
         12,
         0,
         tzinfo=datetime.timezone.utc,
     )
-    assert Time.parse(None) is None
-    assert Time.parse("invalid") is None
+    assert Time().parse(None) is None
+    assert Time().parse("invalid") is None
     assert (
-        Time.quote(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
+        Time().quote(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
         == "'12:00:00+00:00'"
     )
     assert (
-        Time.format(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
+        Time().format(datetime.time(12, 0, tzinfo=datetime.timezone.utc))
         == "12:00:00+00:00"
     )
-    assert Time.format(None) is None
+    assert Time().format(None) is None
 
 
 def test_datetime():
-    assert DateTime.parse("2020-01-01T12:00+00:00") == datetime.datetime(
+    assert DateTime().parse("2020-01-01T12:00+00:00") == datetime.datetime(
         2020,
         1,
         1,
@@ -116,7 +116,7 @@ def test_datetime():
         0,
         tzinfo=datetime.timezone.utc,
     )
-    assert DateTime.parse("2020-01-01T12:00") == datetime.datetime(
+    assert DateTime().parse("2020-01-01T12:00") == datetime.datetime(
         2020,
         1,
         1,
@@ -125,33 +125,33 @@ def test_datetime():
         0,
         tzinfo=datetime.timezone.utc,
     )
-    assert DateTime.parse(None) is None
-    assert DateTime.parse("invalid") is None
+    assert DateTime().parse(None) is None
+    assert DateTime().parse("invalid") is None
     assert (
-        DateTime.quote(
+        DateTime().quote(
             datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
         )
         == "'2020-01-01T12:00:00+00:00'"
     )
     assert (
-        DateTime.format(
+        DateTime().format(
             datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
         )
         == "2020-01-01T12:00:00+00:00"
     )
-    assert DateTime.format(None) is None
+    assert DateTime().format(None) is None
 
 
 def test_boolean():
-    assert Boolean.parse(True) is True
-    assert Boolean.parse(False) is False
-    assert Boolean.parse("true") is True
-    assert Boolean.parse(0) is False
-    assert Boolean.parse(None) is None
-    assert Boolean.quote(True) == "TRUE"
-    assert Boolean.quote(False) == "FALSE"
-    assert Boolean.format(True) == "TRUE"
-    assert Boolean.format(None) is None
+    assert Boolean().parse(True) is True
+    assert Boolean().parse(False) is False
+    assert Boolean().parse("true") is True
+    assert Boolean().parse(0) is False
+    assert Boolean().parse(None) is None
+    assert Boolean().quote(True) == "TRUE"
+    assert Boolean().quote(False) == "FALSE"
+    assert Boolean().format(True) == "TRUE"
+    assert Boolean().format(None) is None
 
 
 def test_type_code():
@@ -168,11 +168,11 @@ def test_type_code():
 
 
 def test_quote():
-    assert Integer.quote(1) == "1"
-    assert Float.quote(1.0) == "1.0"
-    assert String.quote("one") == "'one'"
+    assert Integer().quote(1) == "1"
+    assert Float().quote(1.0) == "1.0"
+    assert String().quote("one") == "'one'"
     assert (
-        DateTime.quote(
+        DateTime().quote(
             datetime.datetime(2021, 6, 3, 7, 0, tzinfo=datetime.timezone.utc),
         )
         == "'2021-06-03T07:00:00+00:00'"


### PR DESCRIPTION
Add support for DML (`INSERT`, `UPDATE`, `DELETE`) in the Google Sheets adapter.

A few notes:

Deletions and updates are based on row ID. When a user runs `DELETE FROM table WHERE condition` the SQLite engine will run a `SELECT * FROM table WHERE condition` on the virtual table, and then use the returned row IDs to run a series of `DELETE FROM table WHERE rowid = ?`.

Ideally we'd use the row number as the row ID when returning data for a `SELECT`, but since it's not exposed in the Chart API we just return sequential numbers. To map those row IDs to the actual rows we store them in a `row_ids` dictionary after every `SELECT`. Then, on a delete or update we fetch the values for the row based on the row ID and delete the first row that matches (since SQL tables have no implicit ordering).

Google Sheets doesn't allow users to input timestamps with timezones, relying instead in a spreadsheet-level timezone. Because of this, when we insert timestamps we need to adjust the values to the spreadsheet timezone before inserting them. This is done by a custom field (`GSheetsDateTime`), and required changing the `parse` and `format` methods in fields to be instance methods.

Currently the adapter does 1 network request per `INSERT`, 2 per `DELETE` (get current state to figure out the row to delete, and then delete it), and 3 per `UPDATE`. Any change made to the sheet by the adapter is pushed immediately, and external changes are also constantly pulled. I want to implement 3 separate modes for the adapter:

1. Bi-directional sync (the current mode)
2. Uni-directional sync (changes are pushed immediately, but the sheet is read only once in the session)
3. Batch mode, where changes are pushed at the end of the session.

I also still need to implement explicit support for `UPDATE` (right now it deletes and inserts), and add timezone management for `Time` objects.