### PR TITLE
feat: Gsheets modes

### DIFF
--- a/src/shillelagh/adapters/api/gsheets.py
+++ b/src/shillelagh/adapters/api/gsheets.py
@@ -483,6 +483,12 @@ class GSheetsAPI(Adapter):
         bounds: Dict[str, Filter],
         order: List[Tuple[str, RequestedOrder]],
     ) -> Iterator[Row]:
+        if self.modified and self._sync_mode == SyncMode.BATCH:
+            _logger.warning(
+                "Spreadsheet has pending changes. If you are deleting or updating "
+                "rows the results might be incorrect!",
+            )
+
         try:
             sql = build_sql(self.columns, bounds, order, self._column_map, self._offset)
         except ImpossibleFilterError:

--- a/src/shillelagh/adapters/api/gsheets.py
+++ b/src/shillelagh/adapters/api/gsheets.py
@@ -284,7 +284,7 @@ def get_sync_mode(uri: str) -> Optional[SyncMode]:
     if "sync_mode" not in qs:
         return None
 
-    parameter = qs["sync_mode"][-1]
+    parameter = qs["sync_mode"][-1].upper()
     try:
         sync_mode = SyncMode[parameter]
     except KeyError:
@@ -660,6 +660,9 @@ class GSheetsAPI(Adapter):
     def close(self) -> None:
         if not self.modified or not self._sync_mode == SyncMode.BATCH:
             return
+
+        # TODO: delete existing data before updating values, since the
+        # number of rows might be smaller
 
         session = self._get_session()
         range_ = f"{self._sheet_name}"

--- a/src/shillelagh/adapters/api/gsheets.py
+++ b/src/shillelagh/adapters/api/gsheets.py
@@ -664,9 +664,11 @@ class GSheetsAPI(Adapter):
         if not self.modified or self._sync_mode != SyncMode.BATCH:
             return
 
-        # pad values with empty rows if needed
         values = self._get_values()
-        values.extend([[]] * (self._original_rows - len(values)))
+
+        # pad values with empty rows if needed
+        dummy_row = [""] * len(self.columns)
+        values.extend([dummy_row] * (self._original_rows - len(values)))
 
         _logger.info("Pushing pending changes to the spreadsheet")
         session = self._get_session()

--- a/tests/adapters/api/test_gsheets.py
+++ b/tests/adapters/api/test_gsheets.py
@@ -1199,7 +1199,7 @@ def test_insert_data(mocker, simple_sheet_adapter):
 
     row_id = gsheets_adapter.insert_row({"country": "UK", "cnt": 10, "rowid": None})
     assert row_id == 0
-    assert gsheets_adapter.row_ids == {0: {"cnt": 10.0, "country": "UK"}}
+    assert gsheets_adapter._row_ids == {0: {"cnt": 10.0, "country": "UK"}}
     assert simple_sheet_adapter.last_request.json() == {
         "range": "Sheet1",
         "majorDimension": "ROWS",
@@ -1208,7 +1208,7 @@ def test_insert_data(mocker, simple_sheet_adapter):
 
     row_id = gsheets_adapter.insert_row({"country": "PY", "cnt": 11, "rowid": 3})
     assert row_id == 3
-    assert gsheets_adapter.row_ids == {
+    assert gsheets_adapter._row_ids == {
         0: {"cnt": 10.0, "country": "UK"},
         3: {"cnt": 11.0, "country": "PY"},
     }
@@ -1251,14 +1251,14 @@ def test_delete_data(mocker, simple_sheet_adapter):
     )
 
     gsheets_adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1/edit", "XXX")
-    gsheets_adapter.row_ids = {
+    gsheets_adapter._row_ids = {
         0: {"cnt": 10.0, "country": "UK"},
         3: {"cnt": 11.0, "country": "PY"},
         4: {"cnt": 12.0, "country": "PL"},
     }
 
     gsheets_adapter.delete_row(0)
-    assert gsheets_adapter.row_ids == {
+    assert gsheets_adapter._row_ids == {
         3: {"cnt": 11.0, "country": "PY"},
         4: {"cnt": 12.0, "country": "PL"},
     }
@@ -1345,14 +1345,14 @@ def test_update_data(mocker, simple_sheet_adapter):
     )
 
     gsheets_adapter = GSheetsAPI("https://docs.google.com/spreadsheets/d/1/edit", "XXX")
-    gsheets_adapter.row_ids = {
+    gsheets_adapter._row_ids = {
         0: {"cnt": 10.0, "country": "UK"},
         3: {"cnt": 11.0, "country": "PY"},
         4: {"cnt": 12.0, "country": "PL"},
     }
 
     gsheets_adapter.update_row(0, {"cnt": 12.0, "country": "UK", "rowid": 0})
-    assert gsheets_adapter.row_ids == {
+    assert gsheets_adapter._row_ids == {
         0: {"cnt": 12.0, "country": "UK"},
         3: {"cnt": 11.0, "country": "PY"},
         4: {"cnt": 12.0, "country": "PL"},
@@ -1381,7 +1381,7 @@ def test_update_data(mocker, simple_sheet_adapter):
         },
     )
     gsheets_adapter.update_row(0, {"cnt": 12.0, "country": "UK", "rowid": 6})
-    assert gsheets_adapter.row_ids == {
+    assert gsheets_adapter._row_ids == {
         6: {"cnt": 12.0, "country": "UK"},
         3: {"cnt": 11.0, "country": "PY"},
         4: {"cnt": 12.0, "country": "PL"},
@@ -1658,7 +1658,7 @@ def test_batch_sync_mode_padding(mocker, simple_sheet_adapter):
     )
 
     row_id = 0
-    gsheets_adapter.row_ids = {row_id: {"cnt": 10.0, "country": "UK"}}
+    gsheets_adapter._row_ids = {row_id: {"cnt": 10.0, "country": "UK"}}
     gsheets_adapter.delete_row(row_id)
     assert gsheets_adapter._values == [
         ["country", "cnt"],

--- a/tests/adapters/api/test_gsheets.py
+++ b/tests/adapters/api/test_gsheets.py
@@ -1674,7 +1674,7 @@ def test_batch_sync_mode_padding(mocker, simple_sheet_adapter):
             ["IN", 5],
             ["ZA", 6],
             ["PY", 11],
-            [],
+            ["", ""],
         ],
     }
 

--- a/tests/adapters/api/test_gsheets.py
+++ b/tests/adapters/api/test_gsheets.py
@@ -1436,6 +1436,12 @@ def test_get_sync_mode():
     )
     assert (
         get_sync_mode(
+            "https://docs.google.com/spreadsheets/d/1/edit?sync_mode=batch#gid=42",
+        )
+        == SyncMode.BATCH
+    )
+    assert (
+        get_sync_mode(
             "https://docs.google.com/spreadsheets/d/1/edit?sync_mode=1#gid=42",
         )
         == SyncMode.BIDIRECTIONAL


### PR DESCRIPTION
Introduce 2 additional sync modes for the Google Sheets adapter:

1. **Bidirectional** (current mode): all changes are pushed immediately, and the spreadsheet is downloaded before every `UPDATE`/`DELETE`. This is very inefficient, but prevent surprises and works good enough with small changes.
2. **Unidirectional**: all changes are pushed immediately, but the spreadsheet is downloaded only once before the first `UPDATE`/`DELETE`. This is at least 2x more efficient, since the state of the spreadsheet is downloaded only once — the bigger the spreadsheet the more efficient it becomes.
3. **Batch**: all changes are pushed at once when the connection closes, and the spreadsheet is downloaded before the first `UPDATE`/`DELETE`: This is the most efficient mode, requiring only 2 network calls, but might result in data loss if the spreadsheet changes during the lifetime of the connection.

Why not always use batch mode? Batch mode is not perfect, since operations are all applied against the original data, and might produce incorrect results. For example, if we have this spreadsheet:

| country | cnt |
| - | - |
| BR | 10 |
| IN | 10 |

And we run these statements in batch mode:

```sql
INSERT INTO table (country, cnt) VALUES (UK, 10);
DELETE FROM table WHERE cnt = 10;
```

The resulting table would look like this:

| country | cnt |
| - | - |
| UK | 10 |

This is because the `DELETE` operates on the original data.