### PR TITLE
feat: add `sleep`, `version`, and `get_metadata` functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,7 @@ repos:
     rev: v2.5.0
     hooks:
     - id: reorder-python-imports
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    - id: debug-statements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 0.7.0 - 2021-MM-DD
 
 - Add support for DML to the Google Sheets adapter
 - Improved many small bugs in the type conversion system
+- Add ``sleep`` and ``get_metadata`` functions
 
 Version 0.6.1 - 2021-06-22
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Version 0.7.0 - 2021-MM-DD
 
 - Add support for DML to the Google Sheets adapter
 - Improved many small bugs in the type conversion system
-- Add ``sleep`` and ``get_metadata`` functions
+- Add ``sleep``, ``version``, and ``get_metadata`` functions
 
 Version 0.6.1 - 2021-06-22
 ==========================

--- a/src/shillelagh/adapters/api/gsheets.py
+++ b/src/shillelagh/adapters/api/gsheets.py
@@ -424,6 +424,30 @@ class GSheetsAPI(Adapter):
             AuthorizedSession(self.credentials) if self.credentials else Session(),
         )
 
+    def get_metadata(self) -> Dict[str, Any]:
+        session = self._get_session()
+        response = session.get(
+            f"https://sheets.googleapis.com/v4/spreadsheets/{self._spreadsheet_id}"
+            "?includeGridData=false",
+        )
+        payload = response.json()
+        if "error" in payload:
+            return {}
+
+        sheets = [
+            sheet
+            for sheet in payload["sheets"]
+            if sheet["properties"]["sheetId"] == self._sheet_id
+        ]
+        if len(sheets) != 1:
+            return {}
+        sheet = sheets[0]
+
+        return {
+            "Spreadsheet title": payload["properties"]["title"],
+            "Sheet title": sheet["properties"]["title"],
+        }
+
     def _run_query(self, sql: str) -> QueryResults:
         quoted_sql = urllib.parse.quote(sql, safe="/()")
         url = f"{self.url}&tq={quoted_sql}"

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -37,6 +37,9 @@ class Adapter:
     def parse_uri(uri: str) -> Tuple[Any, ...]:
         raise NotImplementedError("Subclasses must implement `parse_uri`")
 
+    def get_metadata(self) -> Dict[str, Any]:
+        return {}
+
     def get_columns(self) -> Dict[str, Field]:
         """This method is called for every query, so make sure it's cheap."""
         return dict(

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -24,6 +24,9 @@ class Adapter:
     # disable "unsafe" adapters that write to disk
     safe = False
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        pass  # pragma: no cover
+
     @staticmethod
     def supports(uri: str) -> bool:
         raise NotImplementedError("Subclasses must implement `supports`")

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -326,6 +326,7 @@ class Connection(object):
         # register functions
         available_functions = {
             "sleep": functions.sleep,
+            "version": functions.version,
             "get_metadata": partial(
                 functions.get_metadata,
                 self._adapter_args,

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import urllib.parse
 from collections import Counter
+from functools import partial
 from functools import wraps
 from typing import Any
 from typing import Callable
@@ -17,6 +18,7 @@ from typing import TypeVar
 
 import apsw
 from pkg_resources import iter_entry_points
+from shillelagh import functions
 from shillelagh.adapters.base import Adapter
 from shillelagh.backends.apsw.vt import VTModule
 from shillelagh.exceptions import Error
@@ -320,6 +322,18 @@ class Connection(object):
         self._adapters = adapters
         self._adapter_args = adapter_args
         self._adapter_kwargs = adapter_kwargs
+
+        # register functions
+        available_functions = {
+            "sleep": functions.sleep,
+            "get_metadata": partial(
+                functions.get_metadata,
+                self._adapter_args,
+                self._adapter_kwargs,
+            ),
+        }
+        for name, function in available_functions.items():
+            self._connection.createscalarfunction(name, function)
 
         self.closed = False
         self.cursors: List[Cursor] = []

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -330,6 +330,7 @@ class Connection(object):
                 functions.get_metadata,
                 self._adapter_args,
                 self._adapter_kwargs,
+                adapters,
             ),
         }
         for name, function in available_functions.items():

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -1,0 +1,41 @@
+import json
+import time
+from typing import Any
+from typing import Dict
+
+from pkg_resources import iter_entry_points
+from shillelagh.exceptions import ProgrammingError
+
+
+__all__ = ["sleep", "get_metadata"]
+
+
+def sleep(n: int) -> None:
+    time.sleep(n)
+
+
+def get_metadata(
+    adapter_args: Dict[str, Any],
+    adapter_kwargs: Dict[str, Any],
+    uri: str,
+) -> str:
+    adapters = [
+        entry_point.load() for entry_point in iter_entry_points("shillelagh.adapter")
+    ]
+    for adapter in adapters:
+        if adapter.supports(uri):
+            break
+    else:
+        raise ProgrammingError(f"Unsupported table: {uri}")
+
+    key = adapter.__name__.lower()
+    args = adapter.parse_uri(uri) + adapter_args.get(key, ())
+    kwargs = adapter_kwargs.get(key, {})
+    instance = adapter(*args, **kwargs)
+
+    return json.dumps(
+        {
+            "extra": instance.get_metadata(),
+            "adapter": adapter.__name__,
+        },
+    )

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Tuple
 from typing import Type
 
+import pkg_resources
 from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ProgrammingError
 
@@ -40,3 +41,7 @@ def get_metadata(
             "adapter": adapter.__name__,
         },
     )
+
+
+def version() -> str:
+    return pkg_resources.get_distribution("shillelagh").version

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -2,8 +2,11 @@ import json
 import time
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Type
 
-from pkg_resources import iter_entry_points
+from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ProgrammingError
 
 
@@ -15,13 +18,11 @@ def sleep(n: int) -> None:
 
 
 def get_metadata(
-    adapter_args: Dict[str, Any],
-    adapter_kwargs: Dict[str, Any],
+    adapter_args: Dict[str, Tuple[Any, ...]],
+    adapter_kwargs: Dict[str, Dict[str, Any]],
+    adapters: List[Type[Adapter]],
     uri: str,
 ) -> str:
-    adapters = [
-        entry_point.load() for entry_point in iter_entry_points("shillelagh.adapter")
-    ]
     for adapter in adapters:
         if adapter.supports(uri):
             break

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -44,6 +44,11 @@ def test_adapter_get_columns():
     adapter.close()
 
 
+def test_adapter_get_metadata():
+    adapter = FakeAdapter()
+    assert adapter.get_metadata() == {}
+
+
 def test_adapter_get_data():
     adapter = FakeAdapter()
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,59 @@
+import json
+
+import pytest
+from shillelagh.backends.apsw.db import connect
+from shillelagh.exceptions import ProgrammingError
+from shillelagh.functions import get_metadata
+
+from .fakes import FakeAdapter
+from .fakes import FakeEntryPoint
+
+
+def test_sleep_from_sql(mocker):
+    sleep = mocker.patch("time.sleep")
+    entry_points = [FakeEntryPoint("dummy", FakeAdapter)]
+    mocker.patch(
+        "shillelagh.backends.apsw.db.iter_entry_points",
+        return_value=entry_points,
+    )
+    connection = connect(":memory:", ["dummy"], isolation_level="IMMEDIATE")
+    cursor = connection.cursor()
+    cursor.execute("SELECT sleep(5)")
+
+    sleep.assert_called_with(5)
+
+
+def test_get_metadata(mocker):
+    entry_points = [FakeEntryPoint("dummy", FakeAdapter)]
+    mocker.patch(
+        "shillelagh.functions.iter_entry_points",
+        return_value=entry_points,
+    )
+    assert (
+        get_metadata(
+            {"dummy": ("foo",), "other": ("bar",)},
+            {"dummy": {"key": "value"}, "other": {"one": "two"}},
+            "dummy://",
+        )
+        == '{"extra": {}, "adapter": "FakeAdapter"}'
+    )
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        get_metadata({}, {}, "unsupported://")
+    assert str(excinfo.value) == "Unsupported table: unsupported://"
+
+
+def test_get_metadata_from_sql(mocker):
+    mocker.patch(
+        "shillelagh.functions.get_metadata",
+        return_value=json.dumps({"hello": "world"}),
+    )
+    entry_points = [FakeEntryPoint("dummy", FakeAdapter)]
+    mocker.patch(
+        "shillelagh.backends.apsw.db.iter_entry_points",
+        return_value=entry_points,
+    )
+    connection = connect(":memory:", ["dummy"], isolation_level="IMMEDIATE")
+    cursor = connection.cursor()
+    cursor.execute('SELECT get_metadata("dummy://")')
+    assert cursor.fetchall() == [('{"hello": "world"}',)]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -24,23 +24,23 @@ def test_sleep_from_sql(mocker):
 
 
 def test_get_metadata(mocker):
-    entry_points = [FakeEntryPoint("dummy", FakeAdapter)]
-    mocker.patch(
-        "shillelagh.functions.iter_entry_points",
-        return_value=entry_points,
-    )
     assert (
         get_metadata(
             {"dummy": ("foo",), "other": ("bar",)},
             {"dummy": {"key": "value"}, "other": {"one": "two"}},
+            [FakeAdapter],
             "dummy://",
         )
         == '{"extra": {}, "adapter": "FakeAdapter"}'
     )
 
     with pytest.raises(ProgrammingError) as excinfo:
-        get_metadata({}, {}, "unsupported://")
-    assert str(excinfo.value) == "Unsupported table: unsupported://"
+        get_metadata({}, {}, [], "dummy://")
+    assert str(excinfo.value) == "Unsupported table: dummy://"
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        get_metadata({}, {}, [FakeAdapter], "invalid://")
+    assert str(excinfo.value) == "Unsupported table: invalid://"
 
 
 def test_get_metadata_from_sql(mocker):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,6 @@
 import json
 
+import pkg_resources
 import pytest
 from shillelagh.backends.apsw.db import connect
 from shillelagh.exceptions import ProgrammingError
@@ -57,3 +58,11 @@ def test_get_metadata_from_sql(mocker):
     cursor = connection.cursor()
     cursor.execute('SELECT get_metadata("dummy://")')
     assert cursor.fetchall() == [('{"hello": "world"}',)]
+
+
+def test_version_from_sql(mocker):
+    connection = connect(":memory:")
+    cursor = connection.cursor()
+    cursor.execute("SELECT version()")
+    version = pkg_resources.get_distribution("shillelagh").version
+    assert cursor.fetchall() == [(version,)]


### PR DESCRIPTION
Add 3 useful custom functions:

1. `sleep`, which sleeps for a number of seconds. This is useful for testing timeouts in queries.
2. `get_metadata`, which returns metadata about a given table.
3. `version`, to return the version of the installed Shillelagh.