### PR TITLE
chore: remove `adapter_args`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Version 0.7.0 - 2021-MM-DD
 - Improved many small bugs in the type conversion system
 - Add ``sleep``, ``version``, and ``get_metadata`` functions
 - Add REPL command-line utility (``shillelagh``)
+- Removed ``adapter_args``, use only ``adapter_kwargs`` now
 
 Version 0.6.1 - 2021-06-22
 ==========================

--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -37,7 +37,6 @@ class APSWDialect(SQLiteDialect):
     def __init__(
         self,
         adapters: Optional[List[str]] = None,
-        adapter_args: Optional[Dict[str, Tuple[Any, ...]]] = None,
         adapter_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
         safe: bool = False,
         *args: Any,
@@ -45,7 +44,6 @@ class APSWDialect(SQLiteDialect):
     ):
         super().__init__(*args, **kwargs)
         self._adapters = adapters
-        self._adapter_args = adapter_args
         self._adapter_kwargs = adapter_kwargs
         self._safe = safe
 
@@ -56,7 +54,6 @@ class APSWDialect(SQLiteDialect):
         Tuple[
             str,
             Optional[List[str]],
-            Optional[Dict[str, Tuple[Any, ...]]],
             Optional[Dict[str, Dict[str, Any]]],
             bool,
             Optional[str],
@@ -68,7 +65,6 @@ class APSWDialect(SQLiteDialect):
             (
                 path,
                 self._adapters,
-                self._adapter_args,
                 self._adapter_kwargs,
                 self._safe,
                 self.isolation_level,
@@ -125,9 +121,6 @@ class APSWDialect(SQLiteDialect):
             raise ProgrammingError(f"Unsupported table: {table_name}")
 
         key = adapter.__name__.lower()
-        adapter_args = adapter.parse_uri(table_name) + raw_connection._adapter_args.get(
-            key,
-            (),
-        )
-        adapter_kwargs = raw_connection._adapter_kwargs.get(key, {})
-        return adapter(*adapter_args, **adapter_kwargs)  # type: ignore
+        args = adapter.parse_uri(table_name)
+        kwargs = raw_connection._adapter_kwargs.get(key, {})
+        return adapter(*args, **kwargs)  # type: ignore

--- a/src/shillelagh/backends/apsw/dialects/gsheets.py
+++ b/src/shillelagh/backends/apsw/dialects/gsheets.py
@@ -69,28 +69,25 @@ class APSWGSheetsDialect(APSWDialect):
         Tuple[
             str,
             Optional[List[str]],
-            Optional[Dict[str, Tuple[Any, ...]]],
             Optional[Dict[str, Dict[str, Any]]],
             bool,
             Optional[str],
         ],
         Dict[str, Any],
     ]:
-        query = extract_query(url)
-        adapter_args: Dict[str, Any] = {
-            "gsheetsapi": (
-                query.get("access_token", self.access_token),
-                query.get("service_account_file", self.service_account_file),
-                query.get("service_account_info", self.service_account_info),
-                query.get("subject", self.subject),
-            ),
+        adapter_kwargs: Dict[str, Any] = {
+            "access_token": self.access_token,
+            "service_account_file": self.service_account_file,
+            "service_account_info": self.service_account_info,
+            "subject": self.subject,
         }
+        # overtwrite parameters via query
+        adapter_kwargs.update(extract_query(url))
 
         return (
             ":memory:",
             ["gsheetsapi"],
-            adapter_args,
-            {},
+            {"gsheetsapi": adapter_kwargs},
             True,
             self.isolation_level,
         ), {}

--- a/src/shillelagh/backends/apsw/dialects/safe.py
+++ b/src/shillelagh/backends/apsw/dialects/safe.py
@@ -12,14 +12,12 @@ class APSWSafeDialect(APSWDialect):
     def __init__(
         self,
         adapters: Optional[List[str]] = None,
-        adapter_args: Optional[Dict[str, Any]] = None,
         adapter_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
         *args: Any,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self._adapters = adapters
-        self._adapter_args = adapter_args
         self._adapter_kwargs = adapter_kwargs
         self._safe = True
 
@@ -30,7 +28,6 @@ class APSWSafeDialect(APSWDialect):
         Tuple[
             str,
             Optional[List[str]],
-            Optional[Dict[str, Tuple[Any, ...]]],
             Optional[Dict[str, Dict[str, Any]]],
             bool,
             Optional[str],
@@ -41,7 +38,6 @@ class APSWSafeDialect(APSWDialect):
             (
                 ":memory:",
                 self._adapters,
-                self._adapter_args,
                 self._adapter_kwargs,
                 True,
                 self.isolation_level,

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -19,7 +19,6 @@ def sleep(n: int) -> None:
 
 
 def get_metadata(
-    adapter_args: Dict[str, Tuple[Any, ...]],
     adapter_kwargs: Dict[str, Dict[str, Any]],
     adapters: List[Type[Adapter]],
     uri: str,
@@ -31,7 +30,7 @@ def get_metadata(
         raise ProgrammingError(f"Unsupported table: {uri}")
 
     key = adapter.__name__.lower()
-    args = adapter.parse_uri(uri) + adapter_args.get(key, ())
+    args = adapter.parse_uri(uri)
     kwargs = adapter_kwargs.get(key, {})
     instance = adapter(*args, **kwargs)
 

--- a/tests/backends/apsw/dialects/test_gsheets.py
+++ b/tests/backends/apsw/dialects/test_gsheets.py
@@ -17,8 +17,14 @@ def test_gsheets_dialect():
         (
             ":memory:",
             ["gsheetsapi"],
-            {"gsheetsapi": (None, None, None, None)},
-            {},
+            {
+                "gsheetsapi": {
+                    "access_token": None,
+                    "service_account_file": None,
+                    "service_account_info": None,
+                    "subject": None,
+                },
+            },
             True,
             None,
         ),
@@ -33,8 +39,14 @@ def test_gsheets_dialect():
         (
             ":memory:",
             ["gsheetsapi"],
-            {"gsheetsapi": (None, None, {"secret": "XXX"}, "user@example.com")},
-            {},
+            {
+                "gsheetsapi": {
+                    "access_token": None,
+                    "service_account_file": None,
+                    "service_account_info": {"secret": "XXX"},
+                    "subject": "user@example.com",
+                },
+            },
             True,
             None,
         ),
@@ -49,8 +61,14 @@ def test_gsheets_dialect():
         (
             ":memory:",
             ["gsheetsapi"],
-            {"gsheetsapi": (None, "credentials.json", None, "user@example.com")},
-            {},
+            {
+                "gsheetsapi": {
+                    "access_token": None,
+                    "service_account_file": "credentials.json",
+                    "service_account_info": None,
+                    "subject": "user@example.com",
+                },
+            },
             True,
             None,
         ),

--- a/tests/backends/apsw/dialects/test_safe.py
+++ b/tests/backends/apsw/dialects/test_safe.py
@@ -9,7 +9,6 @@ def test_safe_dialect(fs):
             ":memory:",
             None,
             None,
-            None,
             True,
             None,
         ),

--- a/tests/backends/apsw/test_db.py
+++ b/tests/backends/apsw/test_db.py
@@ -90,7 +90,6 @@ def test_connect_adapter_kwargs(mocker):
     connection.assert_called_with(
         ":memory:",
         [FakeAdapter],
-        {},
         {"fakeadapter": {"foo": "bar"}},
         "IMMEDIATE",
     )
@@ -123,7 +122,6 @@ def test_conect_safe(mocker):
         ":memory:",
         [FakeAdapter1, FakeAdapter2, FakeAdapter3],
         {},
-        {},
         None,
     )
 
@@ -131,7 +129,6 @@ def test_conect_safe(mocker):
     db_Connection.assert_called_with(
         ":memory:",
         [FakeAdapter2],
-        {},
         {},
         None,
     )
@@ -142,7 +139,6 @@ def test_conect_safe(mocker):
         ":memory:",
         [],
         {},
-        {},
         None,
     )
 
@@ -151,7 +147,6 @@ def test_conect_safe(mocker):
     db_Connection.assert_called_with(
         ":memory:",
         [FakeAdapter1],
-        {},
         {},
         None,
     )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -27,7 +27,6 @@ def test_sleep_from_sql(mocker):
 def test_get_metadata(mocker):
     assert (
         get_metadata(
-            {"dummy": ("foo",), "other": ("bar",)},
             {"dummy": {"key": "value"}, "other": {"one": "two"}},
             [FakeAdapter],
             "dummy://",
@@ -36,11 +35,11 @@ def test_get_metadata(mocker):
     )
 
     with pytest.raises(ProgrammingError) as excinfo:
-        get_metadata({}, {}, [], "dummy://")
+        get_metadata({}, [], "dummy://")
     assert str(excinfo.value) == "Unsupported table: dummy://"
 
     with pytest.raises(ProgrammingError) as excinfo:
-        get_metadata({}, {}, [FakeAdapter], "invalid://")
+        get_metadata({}, [FakeAdapter], "invalid://")
     assert str(excinfo.value) == "Unsupported table: invalid://"
 
 


### PR DESCRIPTION
Get rid of `adapter_args` in favor of using only `adapter_kwargs`.