### PR TITLE
feat: support catalogs in GSheets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 0.7.0 - 2021-MM-DD
 
 - Add support for DML to the GSheets adapter
 - GSheets dialect now return "main" as its schema
+- GSheets now supports defining a catalog of spreadsheets
 - Improved many small bugs in the type conversion system
 - Add ``sleep``, ``version``, and ``get_metadata`` functions
 - Add REPL command-line utility (``shillelagh``)

--- a/src/shillelagh/adapters/api/gsheets.py
+++ b/src/shillelagh/adapters/api/gsheets.py
@@ -328,6 +328,10 @@ class GSheetsAPI(Adapter):
 
     @staticmethod
     def supports(uri: str, **kwargs: Any) -> bool:
+        catalog = kwargs.get("catalog", {})
+        if uri in catalog:
+            uri = catalog[uri]
+
         parsed = urllib.parse.urlparse(uri)
         return parsed.netloc == "docs.google.com" and parsed.path.startswith(
             "/spreadsheets/",
@@ -344,7 +348,11 @@ class GSheetsAPI(Adapter):
         service_account_file: Optional[str] = None,
         service_account_info: Optional[Dict[str, Any]] = None,
         subject: Optional[str] = None,
+        catalog: Optional[Dict[str, str]] = None,
     ):
+        if catalog and uri in catalog:
+            uri = catalog[uri]
+
         self.modified = False
 
         # commit changes in batch when the connection is closed or when the

--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -50,27 +50,15 @@ class APSWDialect(SQLiteDialect):
     def create_connect_args(
         self,
         url: URL,
-    ) -> Tuple[
-        Tuple[
-            str,
-            Optional[List[str]],
-            Optional[Dict[str, Dict[str, Any]]],
-            bool,
-            Optional[str],
-        ],
-        Dict[str, Any],
-    ]:
+    ) -> Tuple[Tuple[()], Dict[str, Any]]:
         path = str(url.database) if url.database else ":memory:"
-        return (
-            (
-                path,
-                self._adapters,
-                self._adapter_kwargs,
-                self._safe,
-                self.isolation_level,
-            ),
-            {},
-        )
+        return (), {
+            "path": path,
+            "adapters": self._adapters,
+            "adapter_kwargs": self._adapter_kwargs,
+            "safe": self._safe,
+            "isolation_level": self.isolation_level,
+        }
 
     def do_ping(self, dbapi_connection: _ConnectionFairy) -> bool:
         return True
@@ -116,7 +104,7 @@ class APSWDialect(SQLiteDialect):
         raw_connection = cast(db.Connection, connection.engine.raw_connection())
         for adapter in raw_connection._adapters:
             key = adapter.__name__.lower()
-            kwargs = self._adapter_kwargs.get(key, {})
+            kwargs = raw_connection._adapter_kwargs.get(key, {})
             if adapter.supports(table_name, **kwargs):
                 break
         else:

--- a/src/shillelagh/backends/apsw/dialects/safe.py
+++ b/src/shillelagh/backends/apsw/dialects/safe.py
@@ -24,23 +24,11 @@ class APSWSafeDialect(APSWDialect):
     def create_connect_args(
         self,
         url: URL,
-    ) -> Tuple[
-        Tuple[
-            str,
-            Optional[List[str]],
-            Optional[Dict[str, Dict[str, Any]]],
-            bool,
-            Optional[str],
-        ],
-        Dict[str, Any],
-    ]:
-        return (
-            (
-                ":memory:",
-                self._adapters,
-                self._adapter_kwargs,
-                True,
-                self.isolation_level,
-            ),
-            {},
-        )
+    ) -> Tuple[Tuple[()], Dict[str, Any]]:
+        return (), {
+            "path": ":memory:",
+            "adapters": self._adapters,
+            "adapter_kwargs": self._adapter_kwargs,
+            "safe": True,
+            "isolation_level": self.isolation_level,
+        }

--- a/tests/backends/apsw/dialects/test_safe.py
+++ b/tests/backends/apsw/dialects/test_safe.py
@@ -5,12 +5,12 @@ from sqlalchemy.engine.url import make_url
 def test_safe_dialect(fs):
     dialect = APSWSafeDialect()
     assert dialect.create_connect_args(make_url("shillelagh+safe://")) == (
-        (
-            ":memory:",
-            None,
-            {},
-            True,
-            None,
-        ),
-        {},
+        (),
+        {
+            "path": ":memory:",
+            "adapters": None,
+            "adapter_kwargs": {},
+            "safe": True,
+            "isolation_level": None,
+        },
     )


### PR DESCRIPTION
A catalog is just a map between a readable name and a sheet URL:

```python
    connection = connect(
        ":memory:",
        ["gsheetsapi"],
        adapter_kwargs={
            "gsheetsapi": {
                "catalog": {
                    "sheet": "https://docs.google.com/spreadsheets/d/1/edit#gid=0",
                },
            },
        },
    )
    cursor = connection.cursor()

    sql = "SELECT * FROM sheet"
    data = list(cursor.execute(sql))
    assert data == [
        ("BR", 1),
        ("BR", 3),
        ("IN", 5),
        ("ZA", 6),
        ("CR", 10),
    ]
```