### PR TITLE
chore: move enum to types for consistency

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -29,9 +29,9 @@ from shillelagh.exceptions import ImpossibleFilterError
 from shillelagh.exceptions import InternalError
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field
-from shillelagh.fields import Order
 from shillelagh.filters import Filter
 from shillelagh.lib import build_sql
+from shillelagh.types import Order
 from shillelagh.typing import RequestedOrder
 from shillelagh.typing import Row
 

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -7,9 +7,9 @@ from typing import Type
 from shillelagh.fields import Boolean
 from shillelagh.fields import Date
 from shillelagh.fields import DateTime
-from shillelagh.fields import Order
 from shillelagh.fields import Time
 from shillelagh.filters import Filter
+from shillelagh.types import Order
 
 
 class GSheetsDateTime(DateTime):

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -29,11 +29,11 @@ from shillelagh.adapters.api.gsheets.typing import UrlArgs
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field
 from shillelagh.fields import Float
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import Row
 
 

--- a/src/shillelagh/adapters/api/socrata.py
+++ b/src/shillelagh/adapters/api/socrata.py
@@ -16,12 +16,12 @@ from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Date
 from shillelagh.fields import Field
 from shillelagh.fields import Float
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
 from shillelagh.lib import build_sql
+from shillelagh.types import Order
 from shillelagh.typing import RequestedOrder
 from shillelagh.typing import Row
 from typing_extensions import TypedDict

--- a/src/shillelagh/adapters/api/weatherapi.py
+++ b/src/shillelagh/adapters/api/weatherapi.py
@@ -17,10 +17,10 @@ from shillelagh.fields import Boolean
 from shillelagh.fields import DateTime
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import RequestedOrder
 from shillelagh.typing import Row
 

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -17,11 +17,11 @@ from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import type_map
 from shillelagh.filters import Filter
 from shillelagh.filters import Operator
 from shillelagh.lib import deserialize
+from shillelagh.types import Order
 from shillelagh.typing import Constraint
 from shillelagh.typing import Index
 from shillelagh.typing import RequestedOrder

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -1,6 +1,5 @@
 import datetime
 from distutils.util import strtobool
-from enum import Enum
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -10,21 +9,7 @@ from typing import Type
 
 import dateutil.parser
 from shillelagh.filters import Filter
-
-
-class Order(Enum):
-    # Use ASCENDING/DESCENDING when you have static data with 1+
-    # columns pre-sorted. All other columns should have Order.NONE.
-    ASCENDING = "ascending"
-    DESCENDING = "descending"
-
-    # Use NONE when you can't or don't want to sort the data. Sqlite
-    # will then sort the provided data according to the query.
-    NONE = "none"
-
-    # Use ANY when the column can be sorted in any order. Usually
-    # all other columns will also have Order.ANY.
-    ANY = "any"
+from shillelagh.types import Order
 
 
 class Field:

--- a/src/shillelagh/lib.py
+++ b/src/shillelagh/lib.py
@@ -17,12 +17,12 @@ from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Impossible
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import RequestedOrder
 from shillelagh.typing import Row
 

--- a/src/shillelagh/types.py
+++ b/src/shillelagh/types.py
@@ -1,10 +1,25 @@
 import datetime
 import inspect
 import time
+from enum import Enum
 from typing import Any
 
-from shillelagh.fields import Field
 from typing_extensions import Literal
+
+
+class Order(Enum):
+    # Use ASCENDING/DESCENDING when you have static data with 1+
+    # columns pre-sorted. All other columns should have Order.NONE.
+    ASCENDING = "ascending"
+    DESCENDING = "descending"
+
+    # Use NONE when you can't or don't want to sort the data. Sqlite
+    # will then sort the provided data according to the query.
+    NONE = "none"
+
+    # Use ANY when the column can be sorted in any order. Usually
+    # all other columns will also have Order.ANY.
+    ANY = "any"
 
 
 class DBAPIType:
@@ -12,7 +27,7 @@ class DBAPIType:
         self.name = name
 
     def __eq__(self, other: Any) -> bool:
-        if inspect.isclass(other) and issubclass(other, Field):
+        if inspect.isclass(other) and hasattr(other, "db_api_type"):
             return bool(self.name == other.db_api_type)
 
         return NotImplemented

--- a/src/shillelagh/typing.py
+++ b/src/shillelagh/typing.py
@@ -7,7 +7,7 @@ from typing import Type
 from typing import Union
 
 from shillelagh.fields import Field
-from shillelagh.fields import Order
+from shillelagh.types import Order
 from typing_extensions import Literal
 
 # A value corresponding to a constraint is one of:

--- a/tests/adapters/api/gsheets/test_adapter.py
+++ b/tests/adapters/api/gsheets/test_adapter.py
@@ -14,9 +14,9 @@ from shillelagh.backends.apsw.db import connect
 from shillelagh.exceptions import InternalError
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Float
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
+from shillelagh.types import Order
 
 from ....fakes import FakeAdapter
 from ....fakes import FakeEntryPoint

--- a/tests/adapters/api/gsheets/test_fields.py
+++ b/tests/adapters/api/gsheets/test_fields.py
@@ -6,7 +6,7 @@ from shillelagh.adapters.api.gsheets.fields import GSheetsDate
 from shillelagh.adapters.api.gsheets.fields import GSheetsDateTime
 from shillelagh.adapters.api.gsheets.fields import GSheetsTime
 from shillelagh.fields import DateTime
-from shillelagh.fields import Order
+from shillelagh.types import Order
 
 
 def test_fields():

--- a/tests/adapters/api/gsheets/test_lib.py
+++ b/tests/adapters/api/gsheets/test_lib.py
@@ -17,10 +17,10 @@ from shillelagh.adapters.api.gsheets.lib import get_values_from_row
 from shillelagh.adapters.api.gsheets.types import SyncMode
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Float
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Range
+from shillelagh.types import Order
 
 
 def test_get_field():

--- a/tests/adapters/file/test_csvfile.py
+++ b/tests/adapters/file/test_csvfile.py
@@ -9,10 +9,10 @@ from shillelagh.adapters.file.csvfile import RowTracker
 from shillelagh.backends.apsw.db import connect
 from shillelagh.backends.apsw.vt import VTModule
 from shillelagh.fields import Float
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Impossible
 from shillelagh.filters import Range
+from shillelagh.types import Order
 
 from ...fakes import FakeEntryPoint
 

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -13,11 +13,11 @@ from shillelagh.backends.apsw.db import connect
 from shillelagh.fields import DateTime
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import Row
 
 from ..fakes import FakeAdapter

--- a/tests/backends/apsw/test_db.py
+++ b/tests/backends/apsw/test_db.py
@@ -20,11 +20,11 @@ from shillelagh.exceptions import NotSupportedError
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import Row
 
 from ...fakes import FakeAdapter

--- a/tests/backends/apsw/test_vt.py
+++ b/tests/backends/apsw/test_vt.py
@@ -15,12 +15,12 @@ from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.fields import type_map
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
+from shillelagh.types import Order
 from shillelagh.typing import Row
 
 from ...fakes import FakeAdapter

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -12,12 +12,12 @@ from typing import Tuple
 from shillelagh.adapters.base import Adapter
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Filter
 from shillelagh.filters import Range
 from shillelagh.lib import filter_data
+from shillelagh.types import Order
 from shillelagh.typing import RequestedOrder
 from shillelagh.typing import Row
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,13 +8,13 @@ from shillelagh.fields import DateTime
 from shillelagh.fields import Field
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.fields import Time
 from shillelagh.filters import Equal
 from shillelagh.types import BINARY
 from shillelagh.types import DATETIME
 from shillelagh.types import NUMBER
+from shillelagh.types import Order
 from shillelagh.types import STRING
 
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -3,7 +3,6 @@ from shillelagh.exceptions import ImpossibleFilterError
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Float
 from shillelagh.fields import Integer
-from shillelagh.fields import Order
 from shillelagh.fields import String
 from shillelagh.filters import Equal
 from shillelagh.filters import Impossible
@@ -19,6 +18,7 @@ from shillelagh.lib import RowIDManager
 from shillelagh.lib import serialize
 from shillelagh.lib import unquote
 from shillelagh.lib import update_order
+from shillelagh.types import Order
 
 
 def test_row_id_manager_empty_range():


### PR DESCRIPTION
Move the `Order` enum to `types.py` for consistency.

Closes https://github.com/betodealmeida/shillelagh/issues/58.