### PR TITLE
fix: have all exceptions in `db`

### DIFF
--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name, c-extension-no-member, no-self-use
+# pylint: disable=invalid-name, c-extension-no-member, no-self-use, unused-import
 """
 A DB API 2.0 wrapper for APSW.
 """
@@ -25,9 +25,16 @@ from shillelagh import functions
 from shillelagh.adapters.base import Adapter
 from shillelagh.backends.apsw.vt import type_map
 from shillelagh.backends.apsw.vt import VTModule
+from shillelagh.exceptions import DatabaseError
+from shillelagh.exceptions import DataError
+from shillelagh.exceptions import Error
+from shillelagh.exceptions import IntegrityError
 from shillelagh.exceptions import InterfaceError
+from shillelagh.exceptions import InternalError
 from shillelagh.exceptions import NotSupportedError
+from shillelagh.exceptions import OperationalError
 from shillelagh.exceptions import ProgrammingError
+from shillelagh.exceptions import Warning  # pylint: disable=redefined-builtin
 from shillelagh.fields import Blob
 from shillelagh.fields import Field
 from shillelagh.lib import combine_args_kwargs

--- a/src/shillelagh/exceptions.py
+++ b/src/shillelagh/exceptions.py
@@ -2,6 +2,19 @@
 Exceptions defined in the DB API 2.0 spec.
 """
 
+__all__ = [
+    "Warning",
+    "Error",
+    "InterfaceError",
+    "DatabaseError",
+    "DataError",
+    "OperationalError",
+    "IntegrityError",
+    "InternalError",
+    "ProgrammingError",
+    "NotSupportedError",
+]
+
 
 class Warning(Exception):  # pylint: disable=redefined-builtin
     """


### PR DESCRIPTION
Import all exceptions in the `db` module.