### PR TITLE
fix: time/date and GSheets DML

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Version 0.8.0 - 2021-MM-DD
 ==========================
 
 - Refactor fields
+- Change GSheets to use formatted values
+- Fix bug in GSheets DML with datime/date/time
 
 Version 0.7.4 - 2021-07-03
 ==========================

--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -16,7 +16,6 @@ from typing import Tuple
 
 import dateutil.tz
 from google.auth.transport.requests import AuthorizedSession
-from requests import Request
 from requests import Session
 
 from shillelagh.adapters.api.gsheets.lib import format_error_message
@@ -26,6 +25,7 @@ from shillelagh.adapters.api.gsheets.lib import get_field
 from shillelagh.adapters.api.gsheets.lib import get_index_from_letters
 from shillelagh.adapters.api.gsheets.lib import get_sync_mode
 from shillelagh.adapters.api.gsheets.lib import get_url
+from shillelagh.adapters.api.gsheets.lib import get_value_from_cell
 from shillelagh.adapters.api.gsheets.lib import get_values_from_row
 from shillelagh.adapters.api.gsheets.types import SyncMode
 from shillelagh.adapters.api.gsheets.typing import QueryResults
@@ -286,7 +286,7 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             if rows:
                 self._offset = 1
                 for col, cell in zip(cols, rows[0]["c"]):
-                    col["label"] = cell["v"]
+                    col["label"] = get_value_from_cell(cell)
             else:
                 for col in cols:
                     col["label"] = col["id"]
@@ -406,7 +406,7 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             cols = payload["table"]["cols"]
             rows = (
                 {
-                    reverse_map[col["id"]]: cell["v"] if cell else None
+                    reverse_map[col["id"]]: get_value_from_cell(cell)
                     for col, cell in zip(cols, row["c"])
                     if col["id"] in reverse_map
                 }
@@ -428,8 +428,6 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             row_id = max(self._row_ids.keys()) + 1 if self._row_ids else 0
         self._row_ids[row_id] = row
 
-        # TODO (betodealmeida): this function is incorrect, and doesn't handle
-        # type conversion properly
         row_values = get_values_from_row(row, self._column_map)
 
         # In these modes we keep a local copy of the data, so we only have to
@@ -485,13 +483,12 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             f"https://sheets.googleapis.com/v4/spreadsheets/{self._spreadsheet_id}"
             f"/values/{self._sheet_name}"
         )
-        prepared = Request(
-            "GET",
+        # XXX
+        _logger.info("GET %s", url)
+        response = session.get(
             url,
-            params={"valueRenderOption": "UNFORMATTED_VALUE"},
-        ).prepare()
-        _logger.info("GET %s", prepared.url)
-        response = session.send(prepared)
+            params={"valueRenderOption": "FORMATTED_VALUE"},
+        )
         payload = response.json()
         _logger.debug(payload)
         if "error" in payload:
@@ -603,15 +600,14 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
                 "https://sheets.googleapis.com/v4/spreadsheets/"
                 f"{self._spreadsheet_id}/values/{range_}"
             )
-            prepared = Request(
-                "PUT",
+            # XXX
+            _logger.info("PUT %s", url)
+            _logger.debug(body)
+            response = session.put(
                 url,
                 json=body,
                 params={"valueInputOption": "USER_ENTERED"},
-            ).prepare()
-            _logger.info("PUT %s", prepared.url)
-            _logger.debug(body)
-            response = session.send(prepared)
+            )
             payload = response.json()
             _logger.debug(payload)
             if "error" in payload:
@@ -661,17 +657,16 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             "https://sheets.googleapis.com/v4/spreadsheets/"
             f"{self._spreadsheet_id}/values/{range_}"
         )
-        prepared = Request(
-            "PUT",
+        # XXX
+        _logger.info("PUT %s", url)
+        _logger.debug(body)
+        response = session.put(
             url,
             json=body,
             params={
                 "valueInputOption": "USER_ENTERED",
             },
-        ).prepare()
-        _logger.info("PUT %s", prepared.url)
-        _logger.debug(body)
-        response = session.send(prepared)
+        )
         payload = response.json()
         _logger.debug(payload)
         if "error" in payload:

--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -483,12 +483,14 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             f"https://sheets.googleapis.com/v4/spreadsheets/{self._spreadsheet_id}"
             f"/values/{self._sheet_name}"
         )
-        # XXX
-        _logger.info("GET %s", url)
-        response = session.get(
-            url,
-            params={"valueRenderOption": "FORMATTED_VALUE"},
-        )
+        params = {"valueRenderOption": "FORMATTED_VALUE"}
+
+        # Log the URL. We can't use a prepared request here to extract the URL because
+        # it doesn't work with `AuthorizedSession`.
+        query_string = urllib.parse.urlencode(params)
+        _logger.info("GET %s?%s", url, query_string)
+
+        response = session.get(url, params=params)
         payload = response.json()
         _logger.debug(payload)
         if "error" in payload:
@@ -568,7 +570,11 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
 
         self.modified = True
 
-    def update_data(self, row_id: int, row: Row) -> None:
+    def update_data(  # pylint: disable=too-many-locals
+        self,
+        row_id: int,
+        row: Row,
+    ) -> None:
         """
         Update a row in the sheet.
         """
@@ -600,14 +606,15 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
                 "https://sheets.googleapis.com/v4/spreadsheets/"
                 f"{self._spreadsheet_id}/values/{range_}"
             )
-            # XXX
-            _logger.info("PUT %s", url)
+            params = {"valueInputOption": "USER_ENTERED"}
+
+            # Log the URL. We can't use a prepared request here to extract the URL because
+            # it doesn't work with `AuthorizedSession`.
+            query_string = urllib.parse.urlencode(params)
+            _logger.info("PUT %s?%s", url, query_string)
             _logger.debug(body)
-            response = session.put(
-                url,
-                json=body,
-                params={"valueInputOption": "USER_ENTERED"},
-            )
+
+            response = session.put(url, json=body, params=params)
             payload = response.json()
             _logger.debug(payload)
             if "error" in payload:
@@ -657,16 +664,15 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             "https://sheets.googleapis.com/v4/spreadsheets/"
             f"{self._spreadsheet_id}/values/{range_}"
         )
-        # XXX
-        _logger.info("PUT %s", url)
+        params = {"valueInputOption": "USER_ENTERED"}
+
+        # Log the URL. We can't use a prepared request here to extract the URL because
+        # it doesn't work with `AuthorizedSession`.
+        query_string = urllib.parse.urlencode(params)
+        _logger.info("PUT %s?%s", url, query_string)
         _logger.debug(body)
-        response = session.put(
-            url,
-            json=body,
-            params={
-                "valueInputOption": "USER_ENTERED",
-            },
-        )
+
+        response = session.put(url, json=body, params=params)
         payload = response.json()
         _logger.debug(payload)
         if "error" in payload:

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -20,10 +20,11 @@ from shillelagh.filters import Filter
 # sheet.
 DATETIME_CELL_FORMAT = "%m/%d/%Y %H:%M:%S"
 DATE_CELL_FORMAT = "%m/%d/%Y"
-TIME_CELL_FORMAT = "%H:%M:%S %p"
+TIME_CELL_FORMAT = "%I:%M:%S %p"
 
 # timestamp format used in SQL queries
 DATETIME_SQL_QUOTE = "%Y-%m-%d %H:%M:%S"
+DATE_SQL_QUOTE = "%Y-%m-%d"
 TIME_SQL_QUOTE = "%H:%M:%S"
 
 
@@ -179,6 +180,8 @@ class GSheetsDate(GSheetsField[str, datetime.date]):
             return "null"
 
         # On SQL queries the timestamp should be prefix by "date"
+        format_ = convert_pattern_to_format(self.pattern)
+        value = datetime.datetime.strptime(value, format_).strftime(DATE_SQL_QUOTE)
         return f"date '{value}'"
 
 
@@ -259,9 +262,9 @@ class GSheetsBoolean(GSheetsField[str, bool]):
         return value.lower()
 
 
-class GSheetsFloat(GSheetsField[str, float]):
+class GSheetsNumber(GSheetsField[str, float]):
     """
-    A GSheets float.
+    A GSheets number.
 
     The Google Chart/Sheets APIs return "numbers" only, encoded as strings.
     """
@@ -272,6 +275,11 @@ class GSheetsFloat(GSheetsField[str, float]):
     def parse(self, value: Optional[str]) -> Optional[float]:
         if value is None or value == "":
             return None
+
+        try:
+            return int(value)
+        except ValueError:
+            pass
 
         return float(value)
 

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -2,14 +2,16 @@
 Custom fields for the GSheets adapter.
 """
 import datetime
+from distutils.util import strtobool
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Type
 
+from shillelagh.fields import External
 from shillelagh.fields import Field
+from shillelagh.fields import Internal
 from shillelagh.fields import Order
-from shillelagh.fields import StringBoolean
 from shillelagh.filters import Filter
 
 
@@ -18,53 +20,52 @@ from shillelagh.filters import Filter
 # sheet.
 DATETIME_CELL_FORMAT = "%m/%d/%Y %H:%M:%S"
 DATE_CELL_FORMAT = "%m/%d/%Y"
-TO_TIME_CELL_FORMAT = "%-I:%M:%S %p"
-FROM_TIME_CELL_FORMAT = "%I:%M:%S %p"
+TIME_CELL_FORMAT = "%H:%M:%S %p"
 
 # timestamp format used in SQL queries
 DATETIME_SQL_QUOTE = "%Y-%m-%d %H:%M:%S"
 TIME_SQL_QUOTE = "%H:%M:%S"
 
 
-class GSheetsDateTime(Field[str, datetime.datetime]):
+def convert_pattern_to_format(pattern: Optional[str]) -> str:
     """
-    A GSheets timestamp.
+    Convert a Google Chart API pattern to a python time format.
 
-    The Google Chart API returns timestamps as a string in the following format:
+    Reference: https://developers.google.com/sheets/api/guides/formats?hl=en
+    """
+    # Google Chart API uses ICU to represent patterns. In Python we can use
+    # PyICU to parse the values given a pattern, but the library is difficult
+    # to install and big. For now we have hardcoded values.
+    formats = {
+        "M/d/yyyy H:mm:ss": DATETIME_CELL_FORMAT,
+        "M/d/yyyy": DATE_CELL_FORMAT,
+        "h:mm:ss am/pm": TIME_CELL_FORMAT,
+    }
 
-        Date(2020,0,1,0,0,0) => '2020-01-01 00:00:00'
+    if pattern not in formats:
+        raise NotImplementedError(
+            f'Unknown pattern "{pattern}". Please file a ticket at '
+            "https://github.com/betodealmeida/shillelagh/issues.",
+        )
 
-    (Note that the month is zero-indexed, probably to be compatible with
-    Javascript.)
+    return formats[pattern]
 
-    There are no timezones; instead, there is a global timezone for the whole
-    spreadsheet. The timezone can only be read if the user has set their
-    credentials, since the Google Sheets API used to read metadata about the
-    sheet requires authentication.
 
-    When the timezone is present and read succesfully all timestamps are
-    converted to it, both when fetching data as well as when inserting rows.
-
-    When inserting data timestamps should be formatted differently, and also
-    without a timezone:
-
-        '2020-01-01 00:00:00'
-
-    This field takes care of the conversion between `datetime.datetime` and the
-    two formats.
+class GSheetsField(Field[Internal, External]):
+    """
+    A base class for GSheets fields.
     """
 
-    type = "TIMESTAMP"
-    db_api_type = "DATETIME"
-
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         filters: Optional[List[Type[Filter]]] = None,
         order: Order = Order.NONE,
         exact: bool = False,
+        pattern: Optional[str] = None,
         timezone: Optional[datetime.tzinfo] = None,
     ):
         super().__init__(filters, order, exact)
+        self.pattern = pattern
         self.timezone = timezone
 
     def __eq__(self, other: Any) -> bool:
@@ -75,127 +76,234 @@ class GSheetsDateTime(Field[str, datetime.datetime]):
             self.filters == other.filters
             and self.order == other.order
             and self.exact == other.exact
+            and self.pattern == other.pattern
             and self.timezone == other.timezone,
         )
 
+
+class GSheetsDateTime(GSheetsField[str, datetime.datetime]):
+    """
+    A GSheets timestamp.
+
+    The Google Chart API returns timestamps as a string encoded using an ICU
+    pattern. The default format is "M/d/yyyy H:mm:ss", and values look like
+    this:
+
+        "9/1/2018 0:00:00"
+
+    There are no timezones; instead, there is a global timezone for the whole
+    spreadsheet. The timezone can only be read if the user has set their
+    credentials, since the Google Sheets API used to read metadata about the
+    sheet requires authentication.
+
+    When the timezone is present and read succesfully all timestamps are
+    converted to it, both when fetching data as well as when inserting rows.
+    """
+
+    type = "TIMESTAMP"
+    db_api_type = "DATETIME"
+
     def parse(self, value: Optional[str]) -> Optional[datetime.datetime]:
-        if value is None:
+        # Google Charts API returns `None` for a NULL cell, while the Google
+        # Sheets API returns an empty string
+        if value is None or value == "":
             return None
 
-        args = [int(number) for number in value[len("Date(") : -1].split(",")]
-        args[1] += 1  # month is zero indexed in the response
-        return datetime.datetime(*args, tzinfo=self.timezone)  # type: ignore
+        format_ = convert_pattern_to_format(self.pattern)
+        timestamp = datetime.datetime.strptime(value, format_)
 
-    def format(self, value: Optional[datetime.datetime]) -> Optional[str]:
+        # Set the timestamp to the spreadsheet timezone, if any.
+        timestamp = timestamp.replace(tzinfo=self.timezone)
+
+        return timestamp
+
+    def format(self, value: Optional[datetime.datetime]) -> str:
+        # This method is used only when inserting or updating rows, so we
+        # encode NULLs as an empty string to match the Google Sheets API.
         if value is None:
-            return None
+            return ""
 
         # Google Sheets does not support timezones in datetime values, so we
         # convert all timestamps to the sheet timezone
         if self.timezone:
             value = value.astimezone(self.timezone)
 
-        return value.strftime(DATETIME_CELL_FORMAT) if value else None
+        format_ = convert_pattern_to_format(self.pattern)
+        return value.strftime(format_)
 
     def quote(self, value: Optional[str]) -> str:
-        if value is None:
-            return "NULL"
+        if value == "" or value is None:
+            return "null"
 
         # On SQL queries the timestamp should be prefix by "datetime"
-        value = datetime.datetime.strptime(value, DATETIME_CELL_FORMAT).strftime(
+        format_ = convert_pattern_to_format(self.pattern)
+        value = datetime.datetime.strptime(value, format_).strftime(
             DATETIME_SQL_QUOTE,
         )
         return f"datetime '{value}'"
 
 
-class GSheetsDate(Field[str, datetime.date]):
+class GSheetsDate(GSheetsField[str, datetime.date]):
     """
     A GSheets date.
 
-    The Google Chart API returns timestamps as a string in the following format:
+    The Google Chart API returns dates as a string encoded using an ICU
+    pattern. The default format is "M/d/yyyy", and values look like
+    this:
 
-        Date(2020,0,1) => '2020-01-01'
+        "9/1/2018"
 
-    (Note that the month is zero-indexed, probably to be compatible with
-    Javascript.)
-
-    When inserting data timestamps should be formatted differently:
-
-        '2020-01-01'
-
-    This field takes care of the conversion between `datetime.date` and the
-    two formats.
     """
 
     type = "DATE"
     db_api_type = "DATETIME"
 
     def parse(self, value: Optional[str]) -> Optional[datetime.date]:
-        """Parse a string like 'Date(2018,0,1)'."""
-        if value is None:
+        # Google Charts API returns `None` for a NULL cell, while the Google
+        # Sheets API returns an empty string
+        if value is None or value == "":
             return None
 
-        args = [int(number) for number in value[len("Date(") : -1].split(",")]
-        args[1] += 1  # month is zero indexed in the response (WTF, Google!?)
-        return datetime.date(*args)
+        format_ = convert_pattern_to_format(self.pattern)
+        return datetime.datetime.strptime(value, format_).date()
 
-    def format(self, value: Optional[datetime.date]) -> Optional[str]:
+    def format(self, value: Optional[datetime.date]) -> str:
         if value is None:
-            return None
-        return value.isoformat()
+            return ""
+
+        format_ = convert_pattern_to_format(self.pattern)
+        return value.strftime(format_)
 
     def quote(self, value: Optional[str]) -> str:
-        if value is None:
-            return "NULL"
+        if value == "" or value is None:
+            return "null"
 
         # On SQL queries the timestamp should be prefix by "date"
         return f"date '{value}'"
 
 
-class GSheetsTime(Field[List[int], datetime.time]):
+class GSheetsTime(GSheetsField[str, datetime.time]):
     """
     A GSheets time.
 
-    The Google Chart API return time objects as a list of numbers, corresponding
-    to hour, minute, and seconds.
+    The Google Chart API returns times as a string encoded using an ICU
+    pattern. The default format is "h:mm:ss am/pm", and values look like
+    this:
+
+        "5:00:00 PM"
+
     """
 
     type = "TIME"
     db_api_type = "DATETIME"
 
-    def parse(self, value: Optional[List[int]]) -> Optional[datetime.time]:
+    def parse(self, value: Optional[str]) -> Optional[datetime.time]:
         """
         Parse time of day as returned from the Google Chart API.
         """
-        if value is None:
+        # Google Charts API returns `None` for a NULL cell, while the Google
+        # Sheets API returns an empty string
+        if value is None or value == "":
             return None
 
-        return datetime.time(*value)  # type: ignore
+        format_ = convert_pattern_to_format(self.pattern)
+        return datetime.datetime.strptime(value, format_).time()
 
-    def format(self, value: Optional[datetime.time]) -> Optional[str]:  # type: ignore
+    def format(self, value: Optional[datetime.time]) -> str:
         if value is None:
-            return value
-        return value.strftime(TO_TIME_CELL_FORMAT)
+            return ""
 
-    def quote(self, value: Optional[str]) -> str:  # type: ignore
-        if value is None:
-            return "NULL"
+        format_ = convert_pattern_to_format(self.pattern)
+        return value.strftime(format_)
+
+    def quote(self, value: Optional[str]) -> str:
+        if value == "" or value is None:
+            return "null"
 
         # On SQL queries the timestamp should be prefix by "timeofday"
-        value = datetime.datetime.strptime(value, FROM_TIME_CELL_FORMAT).strftime(
+        format_ = convert_pattern_to_format(self.pattern)
+        value = datetime.datetime.strptime(value, format_).strftime(
             TIME_SQL_QUOTE,
         )
         return f"timeofday '{value}'"
 
 
-class GSheetsBoolean(StringBoolean):
+class GSheetsBoolean(GSheetsField[str, bool]):
     """
     A GSheets boolean.
 
-    Booleans in the Google Chart API are represented as lowercase strings.
+    Booleans in the Google Chart API are return as a string, either "TRUE"
+    of "FALSE".
     """
 
-    def quote(self, value: Optional[str]) -> str:
+    type = "BOOLEAN"
+    db_api_type = "NUMBER"
+
+    def parse(self, value: Optional[str]) -> Optional[bool]:
+        # Google Charts API returns `None` for a NULL cell, while the Google
+        # Sheets API returns an empty string
+        if value is None or value == "":
+            return None
+
+        return bool(strtobool(value))
+
+    def format(self, value: Optional[bool]) -> str:
         if value is None:
-            return "NULL"
+            return ""
+
+        return "TRUE" if value else "FALSE"
+
+    def quote(self, value: Optional[str]) -> str:
+        if value == "" or value is None:
+            return "null"
         return value.lower()
+
+
+class GSheetsFloat(GSheetsField[str, float]):
+    """
+    A GSheets float.
+
+    The Google Chart/Sheets APIs return "numbers" only, encoded as strings.
+    """
+
+    type = "REAL"
+    db_api_type = "NUMBER"
+
+    def parse(self, value: Optional[str]) -> Optional[float]:
+        if value is None or value == "":
+            return None
+
+        return float(value)
+
+    def format(self, value: Optional[float]) -> str:
+        if value is None:
+            return ""
+
+        return str(value)
+
+    def quote(self, value: Optional[str]) -> str:
+        if value == "" or value is None:
+            return "null"
+
+        return str(value)
+
+
+class GSheetsString(GSheetsField[str, str]):
+    """
+    A GSheets string.
+    """
+
+    type = "TEXT"
+    db_api_type = "STRING"
+
+    def parse(self, value: Optional[str]) -> Optional[str]:
+        return None if value == "" else value
+
+    def format(self, value: Optional[str]) -> str:
+        return "" if value is None else value
+
+    def quote(self, value: Optional[str]) -> str:
+        if value == "" or value is None:
+            return "null"
+
+        return f"'{value}'"

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -19,7 +19,7 @@ from shillelagh.adapters.api.gsheets.fields import GSheetsBoolean
 from shillelagh.adapters.api.gsheets.fields import GSheetsDate
 from shillelagh.adapters.api.gsheets.fields import GSheetsDateTime
 from shillelagh.adapters.api.gsheets.fields import GSheetsField
-from shillelagh.adapters.api.gsheets.fields import GSheetsFloat
+from shillelagh.adapters.api.gsheets.fields import GSheetsNumber
 from shillelagh.adapters.api.gsheets.fields import GSheetsString
 from shillelagh.adapters.api.gsheets.fields import GSheetsTime
 from shillelagh.adapters.api.gsheets.types import SyncMode
@@ -53,7 +53,7 @@ def get_field(
     """
     type_map: Dict[str, Tuple[Type[GSheetsField], List[Type[Filter]]]] = {
         "string": (GSheetsString, [Equal]),
-        "number": (GSheetsFloat, [Range]),
+        "number": (GSheetsNumber, [Range]),
         "boolean": (GSheetsBoolean, [Equal]),
         "date": (GSheetsDate, [Range]),
         "datetime": (GSheetsDateTime, [Range]),
@@ -206,10 +206,10 @@ def get_values_from_row(row: Row, column_map: Dict[str, str]) -> List[Any]:
 
 
 def get_credentials(
-    access_token: Optional[str],
-    service_account_file: Optional[str],
-    service_account_info: Optional[Dict[str, Any]],
-    subject: Optional[str],
+    access_token: Optional[str] = None,
+    service_account_file: Optional[str] = None,
+    service_account_info: Optional[Dict[str, Any]] = None,
+    subject: Optional[str] = None,
 ) -> Optional[Credentials]:
     """
     Return a set of credentials.

--- a/src/shillelagh/adapters/api/weatherapi.py
+++ b/src/shillelagh/adapters/api/weatherapi.py
@@ -189,13 +189,13 @@ class WeatherAPI(Adapter):
             response = self._session.get(url)
             if response.ok:
                 payload = response.json()
-                timezone = dateutil.tz.gettz(payload["location"]["tz_id"])
+                local_timezone = dateutil.tz.gettz(payload["location"]["tz_id"])
                 hourly_data = payload["forecast"]["forecastday"][0]["hour"]
                 columns = self.get_columns()
                 for record in hourly_data:
                     row = {column: record[column] for column in columns}
                     row["time"] = dateutil.parser.parse(record["time"]).replace(
-                        tzinfo=timezone,
+                        tzinfo=local_timezone,
                     )
                     row["rowid"] = int(row["time_epoch"])
                     yield row

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -535,7 +535,7 @@ class StringBoolean(Field[str, bool]):
     def parse(self, value: Optional[str]) -> Optional[bool]:
         if value is None:
             return None
-        return bool(strtobool(str(value)))
+        return bool(strtobool(value))
 
     def format(self, value: Optional[bool]) -> Optional[str]:
         if value is None:

--- a/tests/adapters/api/gsheets/test_fields.py
+++ b/tests/adapters/api/gsheets/test_fields.py
@@ -1,87 +1,209 @@
+# pylint: disable=invalid-name
+"""
+Tests for shilellagh.adapters.api.gsheets.fields.
+"""
 import datetime
 
 import dateutil.tz
+import pytest
 
+from shillelagh.adapters.api.gsheets.fields import convert_pattern_to_format
 from shillelagh.adapters.api.gsheets.fields import GSheetsBoolean
 from shillelagh.adapters.api.gsheets.fields import GSheetsDate
 from shillelagh.adapters.api.gsheets.fields import GSheetsDateTime
+from shillelagh.adapters.api.gsheets.fields import GSheetsNumber
+from shillelagh.adapters.api.gsheets.fields import GSheetsString
 from shillelagh.adapters.api.gsheets.fields import GSheetsTime
 from shillelagh.fields import ISODateTime
 from shillelagh.fields import Order
 
 
+def test_convert_pattern_to_format():
+    """
+    Test pattern conversion from ICU to strftime.
+    """
+    assert convert_pattern_to_format("M/d/yyyy H:mm:ss") == "%m/%d/%Y %H:%M:%S"
+    assert convert_pattern_to_format("M/d/yyyy") == "%m/%d/%Y"
+    assert convert_pattern_to_format("h:mm:ss am/pm") == "%I:%M:%S %p"
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        convert_pattern_to_format("hh:mm:ss am/pm")
+    assert str(excinfo.value) == (
+        'Unknown pattern "hh:mm:ss am/pm". Please file a ticket at '
+        "https://github.com/betodealmeida/shillelagh/issues."
+    )
+
+
+def test_comparison():
+    """
+    Test that a GSheets field is different from a standard field.
+    """
+    assert GSheetsDateTime([], Order.NONE, True) != ISODateTime([], Order.NONE, True)
+    assert GSheetsDateTime([], Order.NONE, True) == GSheetsDateTime(
+        [],
+        Order.NONE,
+        True,
+    )
+
+
 def test_GSheetsDateTime():
-    assert GSheetsDateTime().parse("Date(2018,8,9,0,0,0)") == datetime.datetime(
-        2018,
-        9,
-        9,
-        0,
-        0,
-    )
+    """
+    Test GSheetsDateTime.
+    """
     assert GSheetsDateTime().parse(None) is None
-    assert (
-        GSheetsDateTime().format(datetime.datetime(2018, 9, 9, 0, 0))
-        == "09/09/2018 00:00:00"
+    assert GSheetsDateTime().parse("") is None
+
+    assert GSheetsDateTime(pattern="M/d/yyyy H:mm:ss").parse(
+        "12/31/2020 12:34:56",
+    ) == datetime.datetime(
+        2020,
+        12,
+        31,
+        12,
+        34,
+        56,
     )
-    assert GSheetsDateTime().format(None) is None
+
+    assert GSheetsDateTime().format(None) == ""
     assert (
-        GSheetsDateTime().quote("09/09/2018 00:00:00")
-        == "datetime '2018-09-09 00:00:00'"
+        GSheetsDateTime(pattern="M/d/yyyy H:mm:ss").format(
+            datetime.datetime(2020, 12, 31, 12, 34, 56),
+        )
+        == "12/31/2020 12:34:56"
     )
-    assert GSheetsDateTime().quote(None) == "NULL"
+
+    assert GSheetsDateTime().quote(None) == "null"
+    assert GSheetsDateTime().quote("") == "null"
+    assert (
+        GSheetsDateTime(pattern="M/d/yyyy H:mm:ss").quote("12/31/2020 12:34:56")
+        == "datetime '2020-12-31 12:34:56'"
+    )
 
 
 def test_GSheetsDateTime_timezone():
-    tz = dateutil.tz.gettz("America/Los_Angeles")
+    """
+    Test GSheetsDateTime when timezone is set.
+    """
+    timezone = dateutil.tz.gettz("America/Los_Angeles")
+
     assert (
-        GSheetsDateTime(timezone=tz).parse(
-            "Date(2018,8,9,0,0,0)",
+        GSheetsDateTime(pattern="M/d/yyyy H:mm:ss", timezone=timezone).parse(
+            "12/31/2020 12:34:56",
         )
-        == datetime.datetime(2018, 9, 9, 0, 0, tzinfo=tz)
+        == datetime.datetime(2020, 12, 31, 12, 34, 56, tzinfo=timezone)
     )
+
     assert (
-        GSheetsDateTime(timezone=tz).format(
-            datetime.datetime(2018, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+        GSheetsDateTime(pattern="M/d/yyyy H:mm:ss", timezone=timezone).format(
+            datetime.datetime(2020, 12, 31, 12, 34, 56, tzinfo=datetime.timezone.utc),
         )
-        == "12/31/2017 16:00:00"
+        == "12/31/2020 04:34:56"
     )
 
 
 def test_GSheetsDate():
-    assert GSheetsDate().parse("Date(2018,0,1)") == datetime.date(2018, 1, 1)
+    """
+    Test GSheetsDate.
+    """
     assert GSheetsDate().parse(None) is None
-    assert GSheetsDate().format(datetime.date(2018, 1, 1)) == "2018-01-01"
-    assert GSheetsDate().format(None) is None
-    assert GSheetsDate().quote("2018-01-01") == "date '2018-01-01'"
-    assert GSheetsDate().quote(None) == "NULL"
+    assert GSheetsDate().parse("") is None
+
+    assert GSheetsDate(pattern="M/d/yyyy").parse("12/31/2020") == datetime.date(
+        2020,
+        12,
+        31,
+    )
+
+    assert GSheetsDate().format(None) == ""
+    assert (
+        GSheetsDate(pattern="M/d/yyyy").format(datetime.date(2020, 12, 31))
+        == "12/31/2020"
+    )
+
+    assert GSheetsDate().quote(None) == "null"
+    assert GSheetsDate().quote("") == "null"
+    assert GSheetsDate(pattern="M/d/yyyy").quote("12/31/2020") == "date '2020-12-31'"
 
 
 def test_GSheetsTime():
-    assert GSheetsTime().parse([17, 0, 0, 0]) == datetime.time(
-        17,
-        0,
-    )
+    """
+    Test GSheetsTime.
+    """
     assert GSheetsTime().parse(None) is None
-    assert (
-        GSheetsTime().format(datetime.time(17, 0, tzinfo=datetime.timezone.utc))
-        == "5:00:00 PM"
+    assert GSheetsTime().parse("") is None
+
+    assert GSheetsTime(pattern="h:mm:ss am/pm").parse("12:34:56 AM") == datetime.time(
+        0,
+        34,
+        56,
     )
-    assert GSheetsTime().format(None) is None
-    assert GSheetsTime().quote("5:00:00 PM") == "timeofday '17:00:00'"
-    assert GSheetsTime().quote(None) == "NULL"
+
+    assert GSheetsTime().format(None) == ""
+    assert (
+        GSheetsTime(pattern="h:mm:ss am/pm").format(datetime.time(12, 34, 56))
+        == "12:34:56 PM"
+    )
+
+    assert GSheetsTime().quote(None) == "null"
+    assert GSheetsTime().quote("") == "null"
+    assert (
+        GSheetsTime(pattern="h:mm:ss am/pm").quote("12:34:56 AM")
+        == "timeofday '00:34:56'"
+    )
 
 
 def test_GSheetsBoolean():
+    """
+    Test GSheetsBoolean.
+    """
+    assert GSheetsBoolean().parse(None) is None
+    assert GSheetsBoolean().parse("") is None
     assert GSheetsBoolean().parse("TRUE") is True
     assert GSheetsBoolean().parse("FALSE") is False
-    assert GSheetsBoolean().parse(None) is None
+
+    assert GSheetsBoolean().format(None) == ""
     assert GSheetsBoolean().format(True) == "TRUE"
     assert GSheetsBoolean().format(False) == "FALSE"
-    assert GSheetsBoolean().format(None) is None
+
+    assert GSheetsBoolean().quote(None) == "null"
+    assert GSheetsBoolean().quote("") == "null"
     assert GSheetsBoolean().quote("TRUE") == "true"
     assert GSheetsBoolean().quote("FALSE") == "false"
-    assert GSheetsBoolean().quote(None) == "NULL"
 
 
-def test_comparison():
-    assert GSheetsDateTime([], Order.NONE, True) != ISODateTime([], Order.NONE, True)
+def test_GSheetsNumber():
+    """
+    Test GSheetsNumber.
+    """
+    assert GSheetsNumber().parse(None) is None
+    assert GSheetsNumber().parse("") is None
+    assert GSheetsNumber().parse("1") == 1.0
+    assert GSheetsNumber().parse("1.0") == 1.0
+
+    assert isinstance(GSheetsNumber().parse("1"), int)
+    assert isinstance(GSheetsNumber().parse("1.0"), float)
+
+    assert GSheetsNumber().format(None) == ""
+    assert GSheetsNumber().format(1) == "1"
+    assert GSheetsNumber().format(1.0) == "1.0"
+
+    assert GSheetsNumber().quote(None) == "null"
+    assert GSheetsNumber().quote("") == "null"
+    assert GSheetsNumber().quote(1) == "1"
+    assert GSheetsNumber().quote(1.0) == "1.0"
+
+
+def test_GSheetsString():
+    """
+    Test GSheetsString.
+    """
+    assert GSheetsString().parse(None) is None
+    assert GSheetsString().parse("") is None
+    assert GSheetsString().parse("test") == "test"
+
+    assert GSheetsString().format(None) == ""
+    assert GSheetsString().format("test") == "test"
+
+    assert GSheetsString().quote(None) == "null"
+    assert GSheetsString().quote("") == "null"
+    assert GSheetsString().quote("test") == "'test'"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv =
 extras =
     testing
 commands =
-    pytest {posargs} --doctest-modules src/shillelagh
+    pytest {posargs}
 
 
 [testenv:{clean,build}]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv =
 extras =
     testing
 commands =
-    pytest {posargs}
+    pytest --doctest-modules src/shillelagh tests/ {posargs}
 
 
 [testenv:{clean,build}]


### PR DESCRIPTION
This PR changes the GSheets adapter to use the formatted data, since it's common to the Chart and the Sheets APIs.

The Chart API returns timestamps like this:

```json
{"v": "Date(2021,6,7,17,14,33)", "f": "7/7/2021 17:14:33"}
```

Before, we were parsing the value from the `v` field.

We were using the unformatted data in the Sheets API, that looks like this for the same value:

```
44384.71844300038
```

The problem is that this value, when converted to a timestamp, is a few milliseconds off from "7/7/2021 17:14:33", preventing us from finding the row on a DML request.

The formatted data in the Sheets API, on the other hand, looks like this:

```
'7/7/2021 17:14:33'
```

I changed the Chart API to use the formatted value from the `f` field (when available), and the Sheets API to use the formatted data. This way the local values are stored in the same format the ones returned by `get_data`.

Closes https://github.com/betodealmeida/shillelagh/issues/70.