### PR TITLE
feat: return naive time objects by default

### DIFF
--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -339,10 +339,7 @@ class ISODate(Field[str, datetime.date]):
         except dateutil.parser.ParserError:
             return None
 
-        if date.tzinfo is None:
-            date = date.replace(tzinfo=datetime.timezone.utc)
-
-        return date.astimezone(datetime.timezone.utc).date()
+        return date.date()
 
     def format(self, value: Optional[datetime.date]) -> Optional[str]:
         if value is None:
@@ -390,14 +387,14 @@ class ISOTime(Field[str, datetime.time]):
             return None
 
         try:
-            time = dateutil.parser.parse(value)
+            timestamp = dateutil.parser.parse(value)
         except dateutil.parser.ParserError:
             return None
 
-        if time.tzinfo is None:
-            time = time.replace(tzinfo=datetime.timezone.utc)
+        time = timestamp.time()
 
-        return time.astimezone(datetime.timezone.utc).timetz()
+        # timezone is not preserved
+        return time.replace(tzinfo=timestamp.tzinfo)
 
     def format(self, value: Optional[datetime.time]) -> Optional[str]:
         if value is None:
@@ -450,10 +447,7 @@ class ISODateTime(Field[str, datetime.datetime]):
         except dateutil.parser.ParserError:
             return None
 
-        if timestamp.tzinfo is None:
-            timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
-
-        return timestamp.astimezone(datetime.timezone.utc)
+        return timestamp
 
     def format(self, value: Optional[datetime.datetime]) -> Optional[str]:
         if value is None:

--- a/tests/adapters/api/gsheets/test_adapter.py
+++ b/tests/adapters/api/gsheets/test_adapter.py
@@ -558,15 +558,15 @@ def test_convert_rows(mocker):
     data = list(cursor.execute(sql))
     assert data == [
         (
-            datetime.datetime(2018, 9, 1, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 1, 0, 0),
             1.0,
             True,
             datetime.date(2018, 1, 1),
-            datetime.time(17, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.time(17, 0, 0),
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 2, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 2, 0, 0),
             1.0,
             False,
             None,
@@ -574,7 +574,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 3, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 3, 0, 0),
             2.0,
             False,
             None,
@@ -582,7 +582,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 4, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 4, 0, 0),
             3.0,
             False,
             None,
@@ -590,7 +590,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 5, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 5, 0, 0),
             5.0,
             False,
             None,
@@ -598,7 +598,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 6, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 6, 0, 0),
             8.0,
             False,
             None,
@@ -606,7 +606,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 7, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 7, 0, 0),
             13.0,
             False,
             None,
@@ -614,7 +614,7 @@ def test_convert_rows(mocker):
             None,
         ),
         (
-            datetime.datetime(2018, 9, 8, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 8, 0, 0),
             None,
             False,
             None,
@@ -622,7 +622,7 @@ def test_convert_rows(mocker):
             "test",
         ),
         (
-            datetime.datetime(2018, 9, 9, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 9, 0, 0),
             34.0,
             None,
             None,

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from datetime import timezone
 from typing import List
 
 import pytest
@@ -167,7 +166,7 @@ def test_type_conversion(mocker):
     assert cursor.fetchall() == [
         (
             None,
-            datetime(2021, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0),
             None,
             None,
         ),
@@ -177,7 +176,7 @@ def test_type_conversion(mocker):
     assert FakeAdapterWithDateTime.data == [
         {
             "age": None,
-            "birthday": datetime(2021, 1, 1, 0, 0, tzinfo=timezone.utc),
+            "birthday": datetime(2021, 1, 1, 0, 0),
             "name": None,
             "pets": None,
             "rowid": 1,
@@ -190,5 +189,5 @@ def test_type_conversion(mocker):
         (datetime(2020, 12, 31, 0, 0),),
     )
     assert cursor.fetchall() == [
-        (None, datetime(2021, 1, 1, 0, 0, tzinfo=timezone.utc), None, None),
+        (None, datetime(2021, 1, 1, 0, 0), None, None),
     ]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -124,7 +124,6 @@ def test_iso_time():
     assert ISOTime().parse("12:00") == datetime.time(
         12,
         0,
-        tzinfo=datetime.timezone.utc,
     )
     assert ISOTime().parse(None) is None
     assert ISOTime().parse("invalid") is None
@@ -178,7 +177,6 @@ def test_iso_datetime():
         12,
         0,
         0,
-        tzinfo=datetime.timezone.utc,
     )
     assert ISODateTime().parse(None) is None
     assert ISODateTime().parse("invalid") is None


### PR DESCRIPTION
When no timezone is specified, return a naive object.

Closes https://github.com/betodealmeida/shillelagh/issues/22.