### PR TITLE
feat: simplify uris

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 1.x.y - 2021-MM-DD
 
 - Add cost estimation to all adapters
 - Add Datasette adapter
+- Remove ``csv://`` and ``datasette+`` prefixes to simply URIs
 
 Version 1.0.0 - 2021-08-18
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ A query can combine data from multiple adapters:
 
 .. code-block:: sql
 
-    INSERT INTO "csv:///tmp/file.csv"
+    INSERT INTO "/tmp/file.csv"
     SELECT time, chance_of_rain
     FROM "https://api.weatherapi.com/v1/history.json?q=London"
     WHERE time IN (

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -214,8 +214,8 @@ Shillelagh has support for Pandas dataframes, inspired by `DuckDB <https://duckd
 Datasette
 =========
 
-You can select data from any `Datasette <https://datasette.io/>`_ table, appending ``datasette+`` to the URL:
+You can select data from any `Datasette <https://datasette.io/>`_ table, by using the full URL with the database and the table:
 
 .. code-block:: sql
 
-    SELECT * FROM "datasette+https://fivethirtyeight.datasettes.com/polls/president_polls"
+    SELECT * FROM "https://fivethirtyeight.datasettes.com/polls/president_polls"

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -127,11 +127,11 @@ The dialect also allows users to specify a "catalog" of sheets, so they can be r
 CSV files
 =========
 
-CSV (comma separated values) are supported via the ``csv://`` scheme (`an example <https://github.com/betodealmeida/shillelagh/blob/main/examples/csvfile.py>`__):
+CSV (comma separated values) are supported (`an example <https://github.com/betodealmeida/shillelagh/blob/main/examples/csvfile.py>`__):
 
 .. code-block:: sql
 
-    SELECT * FROM "csv:///path/to/file.csv";
+    SELECT * FROM "/path/to/file.csv";
         
 The adapter supports full DML, so you can also ``INSERT``, ``UPDATE``, or ``DELETE`` rows from the CSV file. Deleted rows are marked for deletion, modified and inserted rows are appended at the end of the file, and garbage collection is applied when the connection is closed.
 

--- a/examples/csvfile.py
+++ b/examples/csvfile.py
@@ -4,32 +4,32 @@ if __name__ == "__main__":
     connection = connect(":memory:")
     cursor = connection.cursor()
 
-    sql = '''SELECT * FROM "csv://test.csv"'''
+    sql = '''SELECT * FROM "test.csv"'''
     print(sql)
     for row in cursor.execute(sql):
         print(row)
     print("==")
 
-    sql = """SELECT * FROM "csv://test.csv" WHERE "index" > 11"""
+    sql = """SELECT * FROM "test.csv" WHERE "index" > 11"""
     print(sql)
     for row in cursor.execute(sql):
         print(row)
     print("==")
 
-    sql = """INSERT INTO "csv://test.csv" ("index", temperature, site) VALUES (14, 10.1, 'New_Site')"""
+    sql = """INSERT INTO "test.csv" ("index", temperature, site) VALUES (14, 10.1, 'New_Site')"""
     print(sql)
     cursor.execute(sql)
 
-    sql = """SELECT * FROM "csv://test.csv" WHERE "index" > 11"""
+    sql = """SELECT * FROM "test.csv" WHERE "index" > 11"""
     print(sql)
     for row in cursor.execute(sql):
         print(row)
     print("==")
 
-    sql = """DELETE FROM "csv://test.csv" WHERE site = 'New_Site'"""
+    sql = """DELETE FROM "test.csv" WHERE site = 'New_Site'"""
     print(sql)
     cursor.execute(sql)
-    sql = '''SELECT * FROM "csv://test.csv"'''
+    sql = '''SELECT * FROM "test.csv"'''
     print(sql)
     for row in cursor.execute(sql):
         print(row)

--- a/examples/datasette.py
+++ b/examples/datasette.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     cursor = connection.cursor()
 
     sql = """
-    SELECT * FROM "datasette+https://latest.datasette.io/fixtures/facetable"
+    SELECT * FROM "https://latest.datasette.io/fixtures/facetable"
     """
     for row in cursor.execute(sql):
         print(row)

--- a/src/shillelagh/adapters/file/csvfile.py
+++ b/src/shillelagh/adapters/file/csvfile.py
@@ -92,15 +92,11 @@ class CSVFile(Adapter):
 
     @staticmethod
     def supports(uri: str, **kwargs: Any) -> bool:
-        parsed = urllib.parse.urlparse(uri)
-        return parsed.scheme == "csv"
+        return Path(uri).suffix == ".csv"
 
     @staticmethod
     def parse_uri(uri: str) -> Tuple[str]:
-        parsed = urllib.parse.urlparse(uri)
-
-        # netloc is populated for relative paths, path for absolute
-        return (parsed.path or parsed.netloc,)
+        return (uri,)
 
     def __init__(self, path: str):
         super().__init__()

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -476,7 +476,7 @@ def connect(
         >>> from pyfakefs.fake_filesystem_unittest import Patcher
         >>> with Patcher() as patcher:
         ...     fake_file = patcher.fs.create_file('/foo/bar.csv', contents='"a","b"\n1,2\n3,4')
-        ...     list(curs.execute("SELECT * FROM 'csv:///foo/bar.csv'"))
+        ...     list(curs.execute("SELECT * FROM '/foo/bar.csv'"))
         [(1.0, 2.0), (3.0, 4.0)]
 
     """

--- a/tests/adapters/file/test_csvfile.py
+++ b/tests/adapters/file/test_csvfile.py
@@ -275,7 +275,7 @@ def test_dispatch(mocker, fs):
     connection = connect(":memory:", ["csvfile"])
     cursor = connection.cursor()
 
-    sql = """SELECT * FROM "csv://test.csv" WHERE "index" > 11"""
+    sql = """SELECT * FROM "/test.csv" WHERE "index" > 11"""
     data = list(cursor.execute(sql))
     assert data == [(12.0, 13.3, "Platinum_St"), (13.0, 12.1, "Kodiak_Trail")]
 


### PR DESCRIPTION
Remove the `csv://` and `datasette+` prefixes from URIs.

The URIs look cleaner, the only problem is that for Datasette we now require a `HEAD` request in `supports`, which slows down adapter resolution.

One option would be to implement a fine-grained `supports`, eg:

```python
MAYBE = None

@staticmethod
def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
    parsed = urllib.parse.urlparse(uri)

    if is_known_domain(parsed.netloc):
        return True

    if fast:
        return MAYBE

    return is_datasette(uri)
```

Then we can do a first pass on the adapters looking for `True`, and a second pass with `fast=False` on the ones that returned `MAYBE` on the first pass.