### PR TITLE
[FIX] Security - useing Safeloader

### DIFF
--- a/src/shillelagh/console.py
+++ b/src/shillelagh/console.py
@@ -181,7 +181,7 @@ def main():
     if os.path.exists(config):
         try:
             with open(config) as stream:
-                adapter_kwargs = yaml.load(stream, Loader=yaml.FullLoader)
+                adapter_kwargs = yaml.load(stream, Loader=yaml.SafeLoader)
         except (PermissionError, yaml.parser.ParserError, yaml.scanner.ScannerError):
             _logger.exception("Unable to load configuration file")
 


### PR DESCRIPTION
Using SafeLoader instead of FullLoader to avoid security risks

here is a example proof of concept of arbitrary code execution using Fullloader :

![poc](https://user-images.githubusercontent.com/36979660/136098374-00a8d978-f92b-43e9-b71e-990011c958d9.png)


using safeLoader will fix this 

**Hacktoberfest**