### PR TITLE
Add documentation details for GSheet header rows

### DIFF
--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -113,12 +113,31 @@ The dialect also allows users to specify a "catalog" of sheets, so they can be r
 
 .. code-block:: python
 
-    from sqlalchemy.engine import create_engin
+    from sqlalchemy.engine import create_engine
 
     engine = create_engine(
         "gsheets://",
         "catalog": {
             "simple_sheet": "https://docs.google.com/spreadsheets/d/1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit#gid=0",
+        },
+    )
+    connection = engine.connect()
+    connection.execute("SELECT * FROM simple_sheet")
+
+Header rows
+~~~~~~~~~~~
+The Google Chart API (which is used when fetching data) will "guess" how many rows are headers in the GSheet.  If all your columns are string data, the spreadsheet might have difficulty determining which rows are header rows without this parameter `details <https://developers.google.com/chart/interactive/docs/spreadsheets#creating-a-chart-from-a-separate-spreadsheet>`_ 
+
+You can specify a fixed number of header rows by adding ``headers=N`` to the sheet URI.  eg:
+
+.. code-block:: python
+
+    from sqlalchemy.engine import create_engine
+
+    engine = create_engine(
+        "gsheets://",
+        "catalog": {
+            "simple_sheet": "https://docs.google.com/spreadsheets/d/1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit?headers=1#gid=0",
         },
     )
     connection = engine.connect()


### PR DESCRIPTION
If all columns in a GSheet are string data, the spreadsheet might have difficulty determining which rows are header rows - see https://developers.google.com/chart/interactive/docs/spreadsheets#creating-a-chart-from-a-separate-spreadsheet

Add documentation detailing how to specify the number of header rows as part of the spreadsheet URI