### PR TITLE
fix doc typos

### DIFF
--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -40,7 +40,7 @@ Then, pass the token when creating a connection:
 
     from shillelagh.backends.apsw.db import connect
 
-    connection = connect(":memory:", adapter_kwargs={"gsheetspi": {"access_token": "XXX"}})
+    connection = connect(":memory:", adapter_kwargs={"gsheetsapi": {"access_token": "XXX"}})
 
 For domain wide access you need to create a service account. Make sure that the account has domain delegation enabled, and access to the 3 scopes above. Also make sure that "Google Sheets" and "Google Drive" are enabled in the project. You can then download the credentials as JSON, and pass them either as a file location or as a Python dictionary:
 
@@ -51,7 +51,7 @@ For domain wide access you need to create a service account. Make sure that the 
     connection = connect(
         ":memory:",
         adapter_kwargs={
-            "gsheetspi": {
+            "gsheetaspi": {
                 # "service_account_file": "/path/to/credentials.json",
                 "service_account_info": {
                     "type": "service_account",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -109,7 +109,7 @@ The SQLAlchemy engine can be configured in the same way as the :ref:`dbapi2` ``c
 
     engine = create_engine(
         "shillelagh://",
-         adapters=["gsheetspi"],
+         adapters=["gsheetsapi"],
          adapter_kwargs={
              "gsheetsapi": {
                  "service_account_file": "/path/to/credentials.json",


### PR DESCRIPTION
There are a couple misspelled reference to the gsheetsapi adapter. 

`s/gsheetspi/gsheetsapi`