### PR TITLE
Add support for using Google Application Default Credentials for Google Sheets

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ Contributors
 * David Laing <david@davidlaing.com>
 * Abdul muhaimin <muhaimin@b1nslashsh.tech>
 * Marek Suppa <marek@mareksuppa.com>
+* Bob Callaway <bcallaway@google.com>

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -64,6 +64,15 @@ For domain wide access you need to create a service account. Make sure that the 
 
 You also need to pass a "subject" if you want to impersonate users. If not present the connection will have full access to all spreadsheets in a given project, so be careful.
 
+If running in an environment where Application Default Credentials are available, you can use them by configuring the connection as:
+
+.. code-block:: python
+
+    from shillelagh.backends.apsw.db import connect
+
+    connection = connect(":memory:", adapter_kwargs={"gsheetspi": {"app_default_credentials": True}})
+
+
 Sync modes
 ~~~~~~~~~~
 

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -70,7 +70,7 @@ If running in an environment where Application Default Credentials are available
 
     from shillelagh.backends.apsw.db import connect
 
-    connection = connect(":memory:", adapter_kwargs={"gsheetspi": {"app_default_credentials": True}})
+    connection = connect(":memory:", adapter_kwargs={"gsheetsapi": {"app_default_credentials": True}})
 
 
 Sync modes

--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -97,6 +97,7 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
         service_account_info: Optional[Dict[str, Any]] = None,
         subject: Optional[str] = None,
         catalog: Optional[Dict[str, str]] = None,
+        app_default_credentials: bool = False,
     ):
         super().__init__()
         if catalog and uri in catalog:
@@ -108,6 +109,7 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
             service_account_file,
             service_account_info,
             subject,
+            app_default_credentials,
         )
 
         # Local data. When using DML we switch to the Google Sheets API,

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type
 
 import google.oauth2.credentials
 import google.oauth2.service_account
+import google.auth
 from google.auth.credentials import Credentials
 
 from shillelagh.adapters.api.gsheets.fields import (
@@ -212,6 +213,7 @@ def get_credentials(
     service_account_file: Optional[str] = None,
     service_account_info: Optional[Dict[str, Any]] = None,
     subject: Optional[str] = None,
+    app_default_credentials: Optional[bool] = False,
 ) -> Optional[Credentials]:
     """
     Return a set of credentials.
@@ -219,7 +221,9 @@ def get_credentials(
     The user can provide either an OAuth token directly, the location of a service
     account file, or the contents of the service account directly. When passing
     credentials from a service account the user can also specify a "subject", used
-    to impersonate a given user.
+    to impersonate a given user. Application default credentials can also be used
+    from the environment in lieu of directly specifying a token or service account
+    information.
     """
     if access_token:
         return google.oauth2.credentials.Credentials(access_token)
@@ -237,6 +241,9 @@ def get_credentials(
             scopes=SCOPES,
             subject=subject,
         )
+
+    if app_default_credentials:
+        return google.auth.default(scopes=SCOPES)[0]
 
     return None
 

--- a/src/shillelagh/backends/apsw/dialects/gsheets.py
+++ b/src/shillelagh/backends/apsw/dialects/gsheets.py
@@ -57,6 +57,7 @@ class APSWGSheetsDialect(APSWDialect):
         subject: Optional[str] = None,
         catalog: Optional[Dict[str, str]] = None,
         list_all_sheets: bool = False,
+        app_default_credentials: bool = False,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -67,6 +68,7 @@ class APSWGSheetsDialect(APSWDialect):
         self.subject = subject
         self.catalog = catalog or {}
         self.list_all_sheets = list_all_sheets
+        self.app_default_credentials = app_default_credentials
 
     def create_connect_args(
         self,
@@ -78,6 +80,7 @@ class APSWGSheetsDialect(APSWDialect):
             "service_account_info": self.service_account_info,
             "subject": self.subject,
             "catalog": self.catalog,
+            "app_default_credentials": self.app_default_credentials,
         }
         # parameters can be overridden via the query in the URL
         adapter_kwargs.update(extract_query(url))
@@ -131,6 +134,7 @@ class APSWGSheetsDialect(APSWDialect):
             query.get("service_account_file", self.service_account_file),
             self.service_account_info,
             query.get("subject", self.subject),
+            query.get("app_default_credentials", self.app_default_credentials),
         )
         if not (credentials and self.list_all_sheets):
             return table_names

--- a/tests/adapters/api/gsheets/test_lib.py
+++ b/tests/adapters/api/gsheets/test_lib.py
@@ -280,17 +280,22 @@ def test_get_credentials(mocker: MockerFixture):
     credentials = mocker.patch(
         "shillelagh.adapters.api.gsheets.lib.google.oauth2.credentials.Credentials",
     )
+    app_default_credentials = mocker.patch(
+        "shillelagh.adapters.api.gsheets.lib.google.auth.default",
+    )
 
     # no credentials
     get_credentials(None, None, None, None)
     credentials.assert_not_called()
     service_account.assert_not_called()
+    app_default_credentials.assert_not_called()
 
     # access_token
     get_credentials("token", None, None, None)
     credentials.assert_called_with("token")
     credentials.reset_mock()
     service_account.assert_not_called()
+    app_default_credentials.assert_not_called()
 
     # service_account_file
     get_credentials(None, "credentials.json", None, None)
@@ -304,6 +309,7 @@ def test_get_credentials(mocker: MockerFixture):
         ],
         subject=None,
     )
+    app_default_credentials.assert_not_called()
     service_account.reset_mock()
 
     # service_account_info
@@ -318,6 +324,14 @@ def test_get_credentials(mocker: MockerFixture):
         ],
         subject="user@example.com",
     )
+    app_default_credentials.assert_not_called()
+    service_account.reset_mock()
+
+    # app_default_credentials
+    get_credentials(app_default_credentials=True)
+    credentials.assert_not_called()
+    service_account.assert_not_called()
+    app_default_credentials.assert_called()
 
 
 def test_get_value_from_cell():

--- a/tests/backends/apsw/dialects/test_gsheets.py
+++ b/tests/backends/apsw/dialects/test_gsheets.py
@@ -33,6 +33,7 @@ def test_gsheets_dialect() -> None:
                     "service_account_info": None,
                     "subject": None,
                     "catalog": {},
+                    "app_default_credentials": False,
                 },
             },
             "safe": True,
@@ -56,6 +57,7 @@ def test_gsheets_dialect() -> None:
                     "service_account_info": {"secret": "XXX"},
                     "subject": "user@example.com",
                     "catalog": {},
+                    "app_default_credentials": False,
                 },
             },
             "safe": True,
@@ -80,6 +82,30 @@ def test_gsheets_dialect() -> None:
                     "service_account_info": None,
                     "subject": "user@example.com",
                     "catalog": {"public_sheet": "https://example.com/"},
+                    "app_default_credentials": False,
+                },
+            },
+            "safe": True,
+            "isolation_level": None,
+        },
+    )
+
+    dialect = APSWGSheetsDialect(
+        app_default_credentials=True,
+    )
+    assert dialect.create_connect_args(make_url("gsheets://")) == (
+        (),
+        {
+            "path": ":memory:",
+            "adapters": ["gsheetsapi"],
+            "adapter_kwargs": {
+                "gsheetsapi": {
+                    "access_token": None,
+                    "service_account_file": None,
+                    "service_account_info": None,
+                    "subject": None,
+                    "catalog": {},
+                    "app_default_credentials": True,
                 },
             },
             "safe": True,


### PR DESCRIPTION
This allows for simple authentication when running in an environment where app default credentials are enabled (e.g. Google Cloud Functions, Cloud Run, or on a local development machine where `gcloud auth application-default login` has been run).