### PR TITLE
fix: SQLAlchemy datetime types

### DIFF
--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -6,6 +6,7 @@ import sqlalchemy.types
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
 from sqlalchemy.engine.url import URL
 from sqlalchemy.pool.base import _ConnectionFairy
+from sqlalchemy.sql.type_api import TypeEngine
 from sqlalchemy.sql.visitors import VisitableType
 from typing_extensions import TypedDict
 
@@ -39,6 +40,11 @@ class APSWDialect(SQLiteDialect):
 
     name = "shillelagh"
     driver = "apsw"
+
+    # ``SQLiteDialect.colspecs`` has custom representations for objects that SQLite stores
+    # as string (eg, timestamps). Since the Shillelagh DB API driver returns them as
+    # proper objects the custom representations are not needed.
+    colspecs: Dict[TypeEngine, TypeEngine] = {}
 
     @classmethod
     def dbapi(cls):  # pylint: disable=method-hidden


### PR DESCRIPTION
The SQLite dialect in SQLAlchemy defines its own custom types to handle date/time/datetime stored as string, but Shillelagh already handles that. This PR removes those custom types from the Shillelagh base dialect to prevent SQLAlchemy from trying to double parse.

Closes https://github.com/betodealmeida/shillelagh/issues/193.