### PR TITLE
fix: offset bug in gsheets

### DIFF
--- a/tests/adapters/api/gsheets/test_adapter.py
+++ b/tests/adapters/api/gsheets/test_adapter.py
@@ -1003,7 +1003,7 @@ def test_headers_not_detected(mocker: MockerFixture) -> None:
     )
     adapter.register_uri(
         "GET",
-        "https://docs.google.com/spreadsheets/d/7/gviz/tq?gid=0&tq=SELECT%20%2A%20OFFSET%201",
+        "https://docs.google.com/spreadsheets/d/7/gviz/tq?headers=1&gid=0&tq=SELECT%20%2A",
         json={
             "version": "0.6",
             "reqId": "0",
@@ -1011,9 +1011,9 @@ def test_headers_not_detected(mocker: MockerFixture) -> None:
             "sig": "1227631590",
             "table": {
                 "cols": [
-                    {"id": "A", "label": "", "type": "string"},
-                    {"id": "B", "label": "", "type": "string"},
-                    {"id": "C", "label": "", "type": "string"},
+                    {"id": "A", "label": "Investor", "type": "string"},
+                    {"id": "B", "label": "InvestorName", "type": "string"},
+                    {"id": "C", "label": "Company", "type": "string"},
                 ],
                 "rows": [
                     {


### PR DESCRIPTION
The fix we had for sheets were the first row is not detected correctly as the column names (https://github.com/betodealmeida/shillelagh/commit/24f939923196a37415cfb5a753fc5955768e5fa9) was buggy — it would add an offset of 1 to the query, which only works for `SELECT *`.

This PR fixes the problem by setting `headers=1` on the URL.