### PR TITLE
Fix typo where insert_row was called insert_rows

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -336,7 +336,7 @@ Here's a simple example that supports these methods:
         ) -> Iterator[Dict[str, Any]]:
             yield from iter(self.data)
 
-        def insert_rows(self, row: Dict[str, Any]) -> int:
+        def insert_row(self, row: Dict[str, Any]) -> int:
             row_id: Optional[int] = row["rowid"]
 
             # add a row ID if none was specified


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
