### PR TITLE
Change retrn type of get_cost to be a float

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -446,7 +446,7 @@ You can define a method ``get_cost`` on your adapter to help the query planner t
             self,
             filtered_columns: List[Tuple[str, Operator]],
             order: List[Tuple[str, RequestedOrder]],
-        ) -> int:
+        ) -> float:
             return (
                 100
                 + 1000 * len(filtered_columns)

--- a/src/shillelagh/adapters/api/weatherapi.py
+++ b/src/shillelagh/adapters/api/weatherapi.py
@@ -155,7 +155,7 @@ class WeatherAPI(Adapter):
         self,
         filtered_columns: List[Tuple[str, Operator]],
         order: List[Tuple[str, RequestedOrder]],
-    ) -> int:
+    ) -> float:
         cost = INITIAL_COST
 
         # if the operator is ``Operator.EQ`` we only need to fetch 1 day of data;

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -106,7 +106,7 @@ class Adapter:
         self,
         filtered_columns: List[Tuple[str, Operator]],
         order: List[Tuple[str, RequestedOrder]],
-    ) -> int:
+    ) -> float:
         """
         Estimate the query cost.
 

--- a/src/shillelagh/adapters/file/csvfile.py
+++ b/src/shillelagh/adapters/file/csvfile.py
@@ -139,7 +139,7 @@ class CSVFile(Adapter):
         self,
         filtered_columns: List[Tuple[str, Operator]],
         order: List[Tuple[str, RequestedOrder]],
-    ) -> int:
+    ) -> float:
         cost = INITIAL_COST
 
         # filtering the data has constant cost, since ``filter_data`` builds a

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -276,7 +276,7 @@ class VTTable:
         self,
         constraints: List[Tuple[int, SQLiteConstraint]],
         orderbys: List[Tuple[int, bool]],
-    ) -> Tuple[List[Constraint], int, str, bool, int]:
+    ) -> Tuple[List[Constraint], int, str, bool, float]:
         """
         Build an index for a given set of constraints and order bys.
 


### PR DESCRIPTION
Closes: https://github.com/betodealmeida/shillelagh/issues/227
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
Per https://github.com/rogerbinns/apsw/blob/6913d52acbbb80b5a697d21817de744370ca72d2/src/vtable.c#L798-L804, the estimatedCost should be a double / `float`.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
