### PR TITLE
fix(gsheets): `do_ping`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ spellcheck:
 requirements.txt: .python-version
 	pip install --upgrade pip
 	pip-compile --no-annotate
+
+check:
+	pre-commit run --all-files

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -154,9 +154,14 @@ class Cursor:  # pylint: disable=too-many-instance-attributes
         # this is set to an iterator of rows after a successful query
         self._results: Optional[Iterator[Tuple[Any, ...]]] = None
         self._rowcount = -1
-        
+
         # Approach from: https://github.com/rogerbinns/apsw/issues/160#issuecomment-33927297
-        def exectrace(cursor, sql, bindings):
+        # pylint: disable=unused-argument
+        def exectrace(
+            cursor: "apsw.Cursor",
+            sql: str,
+            bindings: Optional[Tuple[Any, ...]],
+        ) -> bool:
             # In the case of an empty sequence, fall back to None,
             # meaning no rows returned.
             self.description = self._cursor.getdescription() or None
@@ -235,7 +240,7 @@ class Cursor:  # pylint: disable=too-many-instance-attributes
         we need to do the conversion here.
         """
         if not self.description:
-            return
+            return  # pragma: no cover
 
         for row in cursor:
             yield tuple(

--- a/src/shillelagh/backends/apsw/dialects/gsheets.py
+++ b/src/shillelagh/backends/apsw/dialects/gsheets.py
@@ -128,6 +128,9 @@ class APSWGSheetsDialect(APSWDialect):
         updates = [
             update for update in payload if update["service_name"] == "Google Sheets"
         ]
+        if not updates:
+            return True
+
         updates.sort(key=itemgetter("modified"), reverse=True)
         latest_update = updates[0]
         status: str = latest_update["most_recent_update"]["status"]

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -63,9 +63,11 @@ operator_map = {
     apsw.SQLITE_INDEX_CONSTRAINT_LT: Operator.LT,
 }
 
+
 def _add_sqlite_constraint(constant_name: str, operator: Operator) -> None:
     if hasattr(apsw, constant_name):
         operator_map[getattr(apsw, constant_name)] = operator
+
 
 # SQLITE_INDEX_CONSTRAINT_LIKE >= 3.10.0
 _add_sqlite_constraint("SQLITE_INDEX_CONSTRAINT_LIKE", Operator.LIKE)

--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -595,12 +595,11 @@ class StringBoolean(Field[str, bool]):
         Raises ValueError if 'val' is anything else.
         """
         val = val.lower()
-        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        if val in ("y", "yes", "t", "true", "on", "1"):
             return True
-        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        if val in ("n", "no", "f", "false", "off", "0"):
             return False
-        else:
-            raise ValueError("invalid truth value %s" % val)
+        raise ValueError(f"invalid truth value {val}")
 
 
 class IntBoolean(Field[int, bool]):

--- a/tests/adapters/api/test_datasette.py
+++ b/tests/adapters/api/test_datasette.py
@@ -330,5 +330,5 @@ def test_integration(adapter_kwargs) -> None:
             "SOLAR-V1",
             "SOLAR-V1",
             "SOLAR-V1",
-        )
+        ),
     ]

--- a/tests/backends/apsw/dialects/test_gsheets.py
+++ b/tests/backends/apsw/dialects/test_gsheets.py
@@ -346,6 +346,12 @@ def test_do_ping(mocker: MockerFixture, requests_mock: Mocker) -> None:
     )
     assert dialect.do_ping(connection) is False
 
+    requests_mock.get(
+        "https://www.google.com/appsstatus/dashboard/incidents.json",
+        json=[],
+    )
+    assert dialect.do_ping(connection)
+
 
 @pytest.mark.slow_integration_test
 def test_types_in_sqlalchemy(adapter_kwargs: Dict[str, Any]) -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fix `do_ping` in the GSheets dialect, the `incidents.json` had no entries for "Google Sheets" resulting in an error.

Also fix some lint and code coverage.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

```bash
% make test
% make check
```
