### PR TITLE
chore: new logic for escaping quotes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Marek Suppa <marek@mareksuppa.com>
 * Bob Callaway <bcallaway@google.com>
 * Elias Sebbar <contact@eliassebbar.info>
+* Arash Afghahi <arash.afghahi@gmail.com>

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -276,7 +276,8 @@ class VTTable:
         if not columns:
             raise ProgrammingError(f"Virtual table {tablename} has no columns")
 
-        formatted_columns = ", ".join(f'"{k}" {v.type}' for (k, v) in columns.items())
+        quoted_columns = {k.replace('"', '""'): v for k, v in columns.items()}
+        formatted_columns = ", ".join(f'"{k}" {v.type}' for (k, v) in quoted_columns.items())
         return f'CREATE TABLE "{tablename}" ({formatted_columns})'
 
     def BestIndex(  # pylint: disable=too-many-locals


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
Previously when there was a column that only had one quotation mark it would fail to upload the sheet, this add a quotation mark to it which escapes out of the quotation mark. 
# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
