### PR TITLE
test: add integration test for quoted col names

### DIFF
--- a/tests/adapters/api/gsheets/test_integration.py
+++ b/tests/adapters/api/gsheets/test_integration.py
@@ -698,3 +698,22 @@ def test_number_formats(adapter_kwargs: Dict[str, Any]) -> None:
         (1234600000.0, 0.1, 1230000000.0, -123.0, 123.0, 5.125),
         (None, None, None, 123.0, None, None),
     ]
+
+
+@pytest.mark.slow_integration_test
+def test_weird_symbols(adapter_kwargs: Dict[str, Any]) -> None:
+    """
+    Test reading data from a table where the columns have double quotes in their names.
+    """
+    table = (
+        '"https://docs.google.com/spreadsheets/d/'
+        '1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit#gid=767615647"'
+    )
+
+    connection = connect(":memory:", adapter_kwargs=adapter_kwargs)
+    cursor = connection.cursor()
+
+    sql = f"SELECT * FROM {table}"
+    cursor.execute(sql)
+    assert cursor.fetchall() == [(1.0, "a", 45.0), (2.0, "b", 1999.0)]
+    assert [column[0] for column in cursor.description] == ['foo"', '"bar', 'a"b']


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Add integration tests querying https://docs.google.com/spreadsheets/d/1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit#gid=767615647.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
