### PR TITLE
fix: lenient number parser

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/parsing/number.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/number.py
@@ -442,7 +442,15 @@ def parse_number_pattern(value: str, pattern: str) -> float:
         except InvalidValue:
             pass
     else:
-        raise Exception(f"Unable to parse value {value} with pattern {pattern}")
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError as ex:
+                raise Exception(
+                    f"Unable to parse value {value} with pattern {pattern}",
+                ) from ex
 
     # is negative?
     if i == 1 and (len(formats) > 2 or (len(formats) == 2 and "@" not in formats[1])):

--- a/tests/adapters/api/gsheets/parsing/test_number.py
+++ b/tests/adapters/api/gsheets/parsing/test_number.py
@@ -369,13 +369,13 @@ def test_parse_number_pattern_errors() -> None:
     """
     Test errors in ``parse_number_pattern``.
     """
-    with pytest.raises(Exception) as excinfo:
-        parse_number_pattern("80", "##%")
-    assert str(excinfo.value) == "Unable to parse value 80 with pattern ##%"
+    # we fallback to int/float parsing when the format is not correct
+    assert parse_number_pattern("80", "##%") == 80
+    assert parse_number_pattern("1.23", "0.00e+00") == 1.23
 
     with pytest.raises(Exception) as excinfo:
-        parse_number_pattern("1.23", "0.00e+00")
-    assert str(excinfo.value) == "Unable to parse value 1.23 with pattern 0.00e+00"
+        parse_number_pattern("abc", "##%")
+    assert str(excinfo.value) == "Unable to parse value abc with pattern ##%"
 
 
 def test_format_number_pattern() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

When parsing a number, if we can't apply the pattern provided by GSheets we fallback to int/float.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Updated unit tests.