### PR TITLE
feat (gsheets): raise custom auth exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,4 @@ repos:
     language: system
     types: [python]
     exclude: ^templates/
+    args: [--disable=use-implicit-booleaness-not-comparison]

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -277,7 +277,9 @@ class VTTable:
             raise ProgrammingError(f"Virtual table {tablename} has no columns")
 
         quoted_columns = {k.replace('"', '""'): v for k, v in columns.items()}
-        formatted_columns = ", ".join(f'"{k}" {v.type}' for (k, v) in quoted_columns.items())
+        formatted_columns = ", ".join(
+            f'"{k}" {v.type}' for (k, v) in quoted_columns.items()
+        )
         return f'CREATE TABLE "{tablename}" ({formatted_columns})'
 
     def BestIndex(  # pylint: disable=too-many-locals

--- a/src/shillelagh/exceptions.py
+++ b/src/shillelagh/exceptions.py
@@ -121,7 +121,13 @@ class NotSupportedError(DatabaseError):
     """
 
 
-class ImpossibleFilterError(Exception):
+class ImpossibleFilterError(Error):
     """
     Raised when a condition impossible to meet is found (eg, 1=0).
+    """
+
+
+class UnauthenticatedError(InterfaceError):
+    """
+    Custom excepton raised when the user needs to authenticate.
     """

--- a/tests/adapters/api/gsheets/test_integration.py
+++ b/tests/adapters/api/gsheets/test_integration.py
@@ -716,4 +716,5 @@ def test_weird_symbols(adapter_kwargs: Dict[str, Any]) -> None:
     sql = f"SELECT * FROM {table}"
     cursor.execute(sql)
     assert cursor.fetchall() == [(1.0, "a", 45.0), (2.0, "b", 1999.0)]
+    assert cursor.description is not None
     assert [column[0] for column in cursor.description] == ['foo"', '"bar', 'a"b']


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Raise a custom exception when we try to connect to a protected sheet.

This will allow us to capture the exception in Superset, send the user to authorize, store the user token, and use it in subsequent requests.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added tests.