### PR TITLE
feat: DROP TABLE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 pyenv: .python-version
 
-.python-version: setup.cfg
+.python-version: requirements/test.txt
 	if [ -z "`pyenv virtualenvs | grep shillelagh`" ]; then\
 	    pyenv virtualenv shillelagh;\
 	fi
 	if [ ! -f .python-version ]; then\
 	    pyenv local shillelagh;\
 	fi
-	pip install -e '.[testing]'
+	pip install -r requirements/test.txt
 	touch .python-version
 
 test: pyenv

--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -708,3 +708,32 @@ class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
 
         self.modified = False
         _logger.info("Success!")
+
+    def drop_table(self) -> None:
+        """
+        Delete a sheet.
+        """
+        session = self._get_session()
+        body = {
+            "requests": [
+                {
+                    "deleteSheet": {
+                        "sheetId": self._sheet_id,
+                    },
+                },
+            ],
+        }
+        url = (
+            "https://sheets.googleapis.com/v4/spreadsheets/"
+            f"{self._spreadsheet_id}:batchUpdate"
+        )
+        _logger.info("POST %s", url)
+        _logger.debug(body)
+        response = session.post(
+            url,
+            json=body,
+        )
+        payload = response.json()
+        _logger.debug(payload)
+        if "error" in payload:
+            raise ProgrammingError(payload["error"]["message"])

--- a/src/shillelagh/adapters/api/s3select.py
+++ b/src/shillelagh/adapters/api/s3select.py
@@ -301,3 +301,6 @@ class S3SelectAPI(Adapter):
             row["rowid"] = i
             yield row
             _logger.debug(row)
+
+    def drop_table(self) -> None:
+        self.s3_client.delete_object(Bucket=self.bucket, Key=self.key, **self.s3_kwargs)

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -40,6 +40,7 @@ class Adapter:
     # explicitly listed:
     #
     #     >>> engine = create_engine("shillelagh+safe://", adapters=["gsheetsapi"])
+    #
     safe = False
 
     def __init__(self, *args: Any, **kwargs: Any):  # pylint: disable=unused-argument
@@ -194,8 +195,13 @@ class Adapter:
         This method by default will call a delete followed by an insert.
         Adapters can implement their own more efficient methods.
         """
-        self.delete_data(row_id)
-        self.insert_data(row)
+        try:
+            self.delete_data(row_id)
+            self.insert_data(row)
+        except NotSupportedError as ex:
+            raise NotSupportedError(
+                "Adapter does not support ``UPDATE`` statements",
+            ) from ex
 
     def update_row(self, row_id: int, row: Row) -> None:
         """
@@ -215,4 +221,9 @@ class Adapter:
 
         Adapters should use this method to perform any pending changes when the
         connection is closed.
+        """
+
+    def drop_table(self) -> None:
+        """
+        Drop a table.
         """

--- a/src/shillelagh/adapters/file/csvfile.py
+++ b/src/shillelagh/adapters/file/csvfile.py
@@ -237,3 +237,6 @@ class CSVFile(Adapter):
 
         os.replace(self.path.with_suffix(".csv.bak"), self.path)
         self.modified = False
+
+    def drop_table(self) -> None:
+        self.path.unlink()

--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -146,12 +146,9 @@ def get_adapter_for_table_name(
     using the connection to properly pass any adapter kwargs.
     """
     raw_connection = cast(db.Connection, connection.engine.raw_connection())
-    adapter = find_adapter(
+    adapter, args, kwargs = find_adapter(
         table_name,
         raw_connection._adapter_kwargs,
         raw_connection._adapters,
     )
-    key = adapter.__name__.lower()
-    args = adapter.parse_uri(table_name)
-    kwargs = raw_connection._adapter_kwargs.get(key, {})
     return adapter(*args, **kwargs)  # type: ignore

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -48,10 +48,7 @@ def get_metadata(
         }
 
     """
-    adapter = find_adapter(uri, adapter_kwargs, adapters)
-    key = adapter.__name__.lower()
-    args = adapter.parse_uri(uri)
-    kwargs = adapter_kwargs.get(key, {})
+    adapter, args, kwargs = find_adapter(uri, adapter_kwargs, adapters)
     instance = adapter(*args, **kwargs)
 
     return json.dumps(

--- a/src/shillelagh/lib.py
+++ b/src/shillelagh/lib.py
@@ -444,7 +444,7 @@ def find_adapter(
     uri: str,
     adapter_kwargs: Dict[str, Any],
     adapters: List[Type[Adapter]],
-) -> Type[Adapter]:
+) -> Tuple[Type[Adapter], Tuple[Any, ...], Dict[str, Any]]:
     """
     Find an adapter that handles a given URI.
 
@@ -460,7 +460,8 @@ def find_adapter(
         kwargs = adapter_kwargs.get(key, {})
         supported: Optional[bool] = adapter.supports(uri, fast=True, **kwargs)
         if supported:
-            return adapter
+            args = adapter.parse_uri(uri)
+            return adapter, args, kwargs
         if supported is None:
             candidates.add(adapter)
 
@@ -468,6 +469,7 @@ def find_adapter(
         key = adapter.__name__.lower()
         kwargs = adapter_kwargs.get(key, {})
         if adapter.supports(uri, fast=False, **kwargs):
-            return adapter
+            args = adapter.parse_uri(uri)
+            return adapter, args, kwargs
 
     raise ProgrammingError(f"Unsupported table: {uri}")

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -74,7 +74,7 @@ def test_adapter_read_only() -> None:
 
     with pytest.raises(NotSupportedError) as excinfo:
         adapter.update_data(1, {"hello": "universe"})
-    assert str(excinfo.value) == "Adapter does not support ``DELETE`` statements"
+    assert str(excinfo.value) == "Adapter does not support ``UPDATE`` statements"
 
 
 def test_adapter_get_data() -> None:

--- a/tests/backends/apsw/test_db.py
+++ b/tests/backends/apsw/test_db.py
@@ -584,3 +584,21 @@ def test_import_warning(mocker: MockerFixture) -> None:
     _logger.warning.reset_mock()
     connect(":memory:", ["good"])
     _logger.warning.assert_not_called()
+
+
+def test_drop_table(mocker: MockerFixture) -> None:
+    """
+    Test ``drop_table``.
+    """
+    drop_table = mocker.patch.object(FakeAdapter, "drop_table")
+    entry_points = [FakeEntryPoint("dummy", FakeAdapter)]
+    mocker.patch(
+        "shillelagh.backends.apsw.db.iter_entry_points",
+        return_value=entry_points,
+    )
+
+    connection = connect(":memory:", ["dummy"], isolation_level="IMMEDIATE")
+    cursor = connection.cursor()
+
+    cursor.execute('DROP TABLE "dummy://"')
+    drop_table.assert_called()  # type: ignore

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -349,8 +349,10 @@ def test_find_adapter(mocker: MockerFixture) -> None:
     Test ``find_adapter``.
     """
     adapter1 = mocker.MagicMock()
+    adapter1.parse_uri.return_value = ("1",)
     adapter1.configure_mock(__name__="adapter1")
     adapter2 = mocker.MagicMock()
+    adapter2.parse_uri.return_value = ("2",)
     adapter2.configure_mock(__name__="adapter2")
 
     uri = "https://example.com/"
@@ -362,11 +364,11 @@ def test_find_adapter(mocker: MockerFixture) -> None:
 
     adapter1.supports.return_value = True
     adapter2.supports.side_effect = [None, False]
-    assert find_adapter(uri, adapter_kwargs, adapters) == adapter1
+    assert find_adapter(uri, adapter_kwargs, adapters) == (adapter1, ("1",), {})
 
     adapter1.supports.return_value = False
     adapter2.supports.side_effect = [None, True]
-    assert find_adapter(uri, adapter_kwargs, adapters) == adapter2
+    assert find_adapter(uri, adapter_kwargs, adapters) == (adapter2, ("2",), {})
 
 
 def test_is_null() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Add support for `DROP TABLE`. On a statement SQLite will delete the virtual table, and we remove the associated resource, if possible. For example, the GSheets adapter will actually delete the spreadsheet, the S3 adapter will delete the object, etc.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
