### PR TITLE
chore: set supports_sane_rowcount

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Next
 - Add docs on architecture (#273), dialects (#278)
 - Improve docs on custom fields (#275)
 - Configuration directory is now system dependent (#283)
+- Updates should no longer raise errors in SQLAlchemy (#284)
 
 Version 1.0.16 - 2022-07-15
 ===========================

--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -51,6 +51,8 @@ class APSWDialect(SQLiteDialect):
     # proper objects the custom representations are not needed.
     colspecs: Dict[TypeEngine, TypeEngine] = {}
 
+    supports_sane_rowcount = False
+
     @classmethod
     def dbapi(cls):  # pylint: disable=method-hidden
         """


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Before running an update SQLAlchemy with run a `SELECT` statement to get the number of rows about to be modified. After running the update it compares the number of rows from the `SELECT` with the `rowcount` returned by the `UPDATE` query. For `apsw` the row count is zero, so the update fails.

This PR sets `supports_sane_rowcount` to false in the base dialect, so that SQLAlchemy skips the row check.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
