### PR TITLE
chore: improve datetime parsers

### DIFF
--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -28,11 +28,11 @@ from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import (
     Blob,
+    FastISODateTime,
     Field,
     Float,
     IntBoolean,
     ISODate,
-    ISODateTime,
     ISOTime,
     Order,
     RowID,
@@ -96,7 +96,7 @@ type_map: Dict[str, Type[Field]] = {
         IntBoolean,
         StringInteger,
         ISODate,
-        ISODateTime,
+        FastISODateTime,
         ISOTime,
         String,
     ]


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Create a `FastISODateTime` field for SQLite serialization/deserialization, and make the `ISODateTime` field use `dateutil.parser.isoparse` so it works with any valid ISO 8601 values.