### PR TITLE
fix(docs): SyntaxError in catalog parameter

### DIFF
--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -127,7 +127,7 @@ The dialect also allows users to specify a "catalog" of sheets, so they can be r
 
     engine = create_engine(
         "gsheets://",
-        "catalog": {
+        catalog={
             "simple_sheet": "https://docs.google.com/spreadsheets/d/1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit#gid=0",
         },
     )
@@ -147,7 +147,7 @@ You can specify a fixed number of header rows by adding ``headers=N`` to the she
 
     engine = create_engine(
         "gsheets://",
-        "catalog": {
+        catalog={
             "simple_sheet": (
                 "https://docs.google.com/spreadsheets/d/1_rN3lm0R_bU3NemO0s9pbFkY5LQPcuy1pscv8ZXPtg8/edit?"
                 "headers=1"  # <= here


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
Fixes #290 

The code is formatted in black.

# Testing instructions
Since this is a documentation revision, I would like to leave it to GitHub Actions to run tests.
I expect to pass.