### PR TITLE
fix (gsheets): fraction parsing

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/parsing/number.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/number.py
@@ -8,7 +8,7 @@ import math
 import operator
 import re
 from itertools import zip_longest
-from typing import Any, Dict, Iterator, List, Tuple, Union
+from typing import Any, Dict, Iterator, List, Tuple, Union, cast
 
 from shillelagh.adapters.api.gsheets.parsing.base import (
     LITERAL,
@@ -108,7 +108,7 @@ class DIGITS(Token):
             return (
                 {
                     "operation": lambda number: math.copysign(
-                        abs(number) + get_fraction(int(digits)),
+                        abs(number) + get_fraction(digits),
                         number,
                     ),
                 },
@@ -179,7 +179,7 @@ class COMMA(Token):
 
     def parse(self, value: str, tokens: List[Token]) -> Tuple[Dict[str, Any], str]:
         size = len(self.token)
-        return {"operation": lambda number: number * 1000 ** size}, value
+        return {"operation": lambda number: number * 1000**size}, value
 
 
 class E(Token):  # pylint: disable=invalid-name
@@ -229,7 +229,7 @@ class E(Token):  # pylint: disable=invalid-name
         exponent = int(match.group(2))
         size = len(match.group())
 
-        return {"operation": lambda number: number * 10 ** exponent}, value[size:]
+        return {"operation": lambda number: number * 10**exponent}, value[size:]
 
 
 class FRACTION(Token):
@@ -266,7 +266,7 @@ class FRACTION(Token):
             # the denominator needs to be formatted as a fraction, with spaces and zeros
             # right padded
             pattern = "." + groups[1]
-            number = get_fraction(denominator)
+            number = get_fraction(str(denominator))
             formatted_denominator = format_number_pattern(number, pattern).lstrip(".")
 
         if math.floor(numerator) == 0:
@@ -404,28 +404,24 @@ class CONDITION(Token):
         return {}, value
 
 
-def get_fraction(number: int) -> float:
+def get_fraction(number: str) -> float:
     """
     Return the fraction associated with a fractional part.
 
-        >>> get_fraction(9)
+        >>> get_fraction("9")
         0.9
-        >>> get_fraction(123)
+        >>> get_fraction("123")
         0.123
-        >>> get_fraction(1)
+        >>> get_fraction("1")
         0.1
+        >>> get_fraction("001")
+        0.001
 
     """
-    if number < 0:
+    if int(number) < 0:
         raise Exception("Number should be a positive integer")
 
-    # we could do this analytically, but there are too many edge
-    # cases (0 and 10^n, eg)
-    result = float(number)
-    while result >= 1:
-        result /= 10
-
-    return result
+    return cast(float, int(number) / (10 ** len(number)))
 
 
 def parse_number_pattern(value: str, pattern: str) -> float:
@@ -504,7 +500,7 @@ def parse_number_format(value: str, format_: str) -> float:
 
 def has_condition(pattern: str) -> bool:
     """
-    Return true if the pattern has condition metra instructions.
+    Return true if the pattern has condition instructions.
     """
     return bool(re.match(r"\[(>|>=|<|<=|=)\d*(\.\d*)?\]", pattern))
 

--- a/tests/adapters/api/gsheets/parsing/number_test.py
+++ b/tests/adapters/api/gsheets/parsing/number_test.py
@@ -281,14 +281,15 @@ def test_get_fraction() -> None:
     """
     Test ``get_fraction``.
     """
-    assert get_fraction(9) == 0.9
-    assert get_fraction(123) == 0.123
-    assert get_fraction(1) == 0.1
-    assert get_fraction(10) == 0.1
-    assert get_fraction(0) == 0
+    assert get_fraction("9") == 0.9
+    assert get_fraction("123") == 0.123
+    assert get_fraction("1") == 0.1
+    assert get_fraction("001") == 0.001
+    assert get_fraction("10") == 0.1
+    assert get_fraction("0") == 0
 
     with pytest.raises(Exception) as excinfo:
-        get_fraction(-1)
+        get_fraction("-1")
     assert str(excinfo.value) == "Number should be a positive integer"
 
 
@@ -346,6 +347,9 @@ def test_parse_number_pattern() -> None:
     assert parse_number_pattern("dollars: 12.0", "dollars: #.0#") == 12
     assert parse_number_pattern("1.23e-02", "0.00e+00") == 0.0123
     assert parse_number_pattern("0123.45", "#0000.00") == 123.45
+
+    # regressions
+    assert parse_number_pattern("1.001", "#,##0.000") == 1.001
 
     # tests for conditions
     assert (


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fix a bug in the GSheets adapter where the number "1.001" was being incorrectly parsed as "1.1". This was happening because when parsing the fractional part `001` with the `get_fraction` we were getting `0.1` instead of `0.001`. I fixed the logic in `get_fraction`.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Updated unit tests and added tests covering the bug.