### PR TITLE
fix (gsheets): handle negative case

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/parsing/number.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/number.py
@@ -179,7 +179,7 @@ class COMMA(Token):
 
     def parse(self, value: str, tokens: List[Token]) -> Tuple[Dict[str, Any], str]:
         size = len(self.token)
-        return {"operation": lambda number: number * 1000**size}, value
+        return {"operation": lambda number: number * 1000 ** size}, value
 
 
 class E(Token):  # pylint: disable=invalid-name
@@ -229,7 +229,7 @@ class E(Token):  # pylint: disable=invalid-name
         exponent = int(match.group(2))
         size = len(match.group())
 
-        return {"operation": lambda number: number * 10**exponent}, value[size:]
+        return {"operation": lambda number: number * 10 ** exponent}, value[size:]
 
 
 class FRACTION(Token):
@@ -436,7 +436,13 @@ def parse_number_pattern(value: str, pattern: str) -> float:
             number = parse_number_format(value, format_)
             break
         except InvalidValue:
-            pass
+            # weird edge case
+            if value.startswith("-"):
+                try:
+                    number = -parse_number_pattern(value[1:], format_)
+                    break
+                except Exception:  # pylint: disable=broad-except
+                    pass
     else:
         try:
             return int(value)
@@ -450,7 +456,7 @@ def parse_number_pattern(value: str, pattern: str) -> float:
 
     # is negative?
     if i == 1 and (len(formats) > 2 or (len(formats) == 2 and "@" not in formats[1])):
-        return number * -1
+        return -number
 
     return number
 

--- a/tests/adapters/api/gsheets/parsing/number_test.py
+++ b/tests/adapters/api/gsheets/parsing/number_test.py
@@ -368,6 +368,13 @@ def test_parse_number_pattern() -> None:
         == 123
     )
 
+    # corner cases
+    assert parse_number_pattern("$12.2", "$#0.0,,") == 12200000.0
+    assert parse_number_pattern("-$12.2", "$#0.0,,") == -12200000.0
+    with pytest.raises(Exception) as excinfo:
+        assert parse_number_pattern("-$12.2", "#")
+    assert str(excinfo.value) == "Unable to parse value -$12.2 with pattern #"
+
 
 def test_parse_number_pattern_errors() -> None:
     """


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fix for GSheets where this was not true:

```python
assert parse_number_pattern("-$12.2", "$#0.0,,") == -12200000.0
```

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added tests.
