### PR TITLE
fix: don't load non-requested adapters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Fix preventing loading of non-requested adapters (#303)
+
 Version 1.1.1 - 2022-10-26
 ==========================
 

--- a/src/shillelagh/adapters/registry.py
+++ b/src/shillelagh/adapters/registry.py
@@ -88,13 +88,10 @@ class AdapterLoader:
 
         If no adapters are specified, return all.
         """
-        all_adapters = {name: self.load(name, safe=False) for name in self.loaders}
-
-        if adapters is None:
-            return all_adapters
-
         return {
-            name: adapter for name, adapter in all_adapters.items() if name in adapters
+            name: self.load(name, safe=False)
+            for name in self.loaders
+            if adapters is None or name in adapters
         }
 
     def register(self, name: str, modulepath: str, classname: str) -> None:

--- a/tests/adapters/registry_test.py
+++ b/tests/adapters/registry_test.py
@@ -57,3 +57,21 @@ def test_register(registry: AdapterLoader) -> None:
     with pytest.raises(InterfaceError) as excinfo:
         registry.load("invalid")
     assert str(excinfo.value) == "Unable to load adapter invalid"
+
+
+def test_load_only_requested_adapters(registry: AdapterLoader) -> None:
+    """
+    Test that we only try to load requested adapters.
+    """
+    registry.clear()
+
+    def load_error() -> None:
+        raise ImportError("Error!")
+
+    registry.add("valid", FakeAdapter)
+    registry.loaders["invalid"].append(load_error)
+
+    assert registry.load_all(["valid"]) == {"valid": FakeAdapter}
+    with pytest.raises(InterfaceError) as excinfo:
+        registry.load_all()
+    assert str(excinfo.value) == "Unable to load adapter invalid"


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

The adapter registry was trying to load adapters even if they were not explicitly requested, which could break in case some optional dependencies were missing.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added unit test.