### PR TITLE
chore: improve generic JSON adapter

### DIFF
--- a/examples/generic_json.py
+++ b/examples/generic_json.py
@@ -1,0 +1,57 @@
+"""
+A simple example showing the generic JSON.
+
+In this example, the JSON response looks like this:
+
+    {
+      "domains": [
+        {
+          "domain": "facebook-domain-verification8n83p6fzqi04yqdhyqb3vjpv73hzp9.com",
+          "create_date": "2022-11-02T14:22:04.363028",
+          "update_date": "2022-11-02T14:22:04.363030",
+          "country": null,
+          "isDead": "False",
+          "A": null,
+          "NS": null,
+          "CNAME": null,
+          "MX": null,
+          "TXT": null
+        },
+        {
+          "domain": "facebook-password-recover.com",
+          "create_date": "2022-11-02T14:22:04.363231",
+          "update_date": "2022-11-02T14:22:04.363233",
+          "country": null,
+          "isDead": "False",
+          "A": null,
+          "NS": null,
+          "CNAME": null,
+          "MX": null,
+          "TXT": null
+        },
+        ...
+      ],
+      "total": 742,
+      "time": "6",
+      "next_page": null
+    }
+
+To get the actual data we need to specify the following JSONPath expression:
+
+    $.domains[*]
+
+"""
+
+from shillelagh.backends.apsw.db import connect
+
+if __name__ == "__main__":
+    connection = connect(":memory:")
+    cursor = connection.cursor()
+
+    SQL = """
+    SELECT * FROM
+    "https://api.domainsdb.info/v1/domains/search?domain=facebook&zone=com#$.domains[*]"
+    LIMIT 2
+    """
+    for row in cursor.execute(SQL):
+        print(row)


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Improve the generic JSON adapter, adding error handling and flattening or recursive values.

Also add an example of using the adapter.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

```
$ shillelagh
sql> SELECT * FROM "https://api.domainsdb.info/v1/domains/search?domain=facebook&zone=com#$.domains[*]";
```
