### PR TITLE
fix: support booleans on type inferral

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Support booleans when inferring types from data (#318)
+
 Version 1.1.4 - 2022-12-06
 ==========================
 

--- a/src/shillelagh/lib.py
+++ b/src/shillelagh/lib.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, T
 
 from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ImpossibleFilterError, ProgrammingError
-from shillelagh.fields import Field, Float, Integer, Order, String
+from shillelagh.fields import Boolean, Field, Float, Integer, Order, String
 from shillelagh.filters import (
     Equal,
     Filter,
@@ -135,7 +135,7 @@ class RowIDManager:
         raise Exception(f"Row ID {row_id} not found")
 
 
-def analyze(
+def analyze(  # pylint: disable=too-many-branches
     data: Iterator[Row],
 ) -> Tuple[int, Dict[str, Order], Dict[str, Type[Field]]]:
     """
@@ -170,8 +170,16 @@ def analyze(
                 types[column_name] = Float
             elif types.get(column_name) == Integer:
                 continue
-            else:
+            # ``isintance(True, int) == True`` :(
+            elif isinstance(value, int) and not isinstance(value, bool):
                 types[column_name] = Integer
+            elif types.get(column_name) == Boolean:
+                continue
+            elif isinstance(value, bool):
+                types[column_name] = Boolean
+            else:
+                # something weird, use string
+                types[column_name] = String
 
         previous_row = row
 

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from shillelagh.exceptions import ImpossibleFilterError, ProgrammingError
-from shillelagh.fields import Field, Float, Integer, Order, String
+from shillelagh.fields import Boolean, Field, Float, Integer, Order, String
 from shillelagh.filters import (
     Equal,
     Filter,
@@ -110,9 +110,30 @@ def test_analyze() -> None:
     """
     data: Iterator[Dict[str, Any]] = iter(
         [
-            {"int": 1, "float": 10.0, "str": "Alice"},
-            {"int": 3, "float": 9.5, "str": "Bob"},
-            {"int": 2, "float": 8.0, "str": "Charlie"},
+            {
+                "int": 1,
+                "float": 10.0,
+                "str": "Alice",
+                "bool": False,
+                "list": [1],
+                "weird": set(),
+            },
+            {
+                "int": 3,
+                "float": 9.5,
+                "str": "Bob",
+                "bool": True,
+                "list": [2],
+                "weird": {1},
+            },
+            {
+                "int": 2,
+                "float": 8.0,
+                "str": "Charlie",
+                "bool": False,
+                "list": [3],
+                "weird": {1, 2},
+            },
         ],
     )
     num_rows, order, types = analyze(data)
@@ -121,8 +142,18 @@ def test_analyze() -> None:
         "int": Order.NONE,
         "float": Order.DESCENDING,
         "str": Order.ASCENDING,
+        "bool": Order.NONE,
+        "list": Order.ASCENDING,
+        "weird": Order.ASCENDING,
     }
-    assert types == {"int": Integer, "float": Float, "str": String}
+    assert types == {
+        "int": Integer,
+        "float": Float,
+        "str": String,
+        "bool": Boolean,
+        "list": String,
+        "weird": String,
+    }
 
 
 def test_update_order() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
