### PR TITLE
fix: handle dataframes without column names

### DIFF
--- a/src/shillelagh/adapters/memory/pandas.py
+++ b/src/shillelagh/adapters/memory/pandas.py
@@ -81,6 +81,9 @@ def get_df_data(  # pylint: disable=too-many-arguments
     """
     Apply the ``get_data`` method on a Pandas dataframe.
     """
+    # ensure column names are strings
+    df = df.rename(columns={k: str(k) for k in df.columns})
+
     column_names = list(columns.keys())
     df = df[column_names]
 
@@ -124,7 +127,8 @@ def get_columns_from_df(df: pd.DataFrame) -> Dict[str, Field]:
     Construct adapter columns from a Pandas dataframe.
     """
     return {
-        column_name: get_field(dtype)
+        # ensure column name is string
+        str(column_name): get_field(dtype)
         for column_name, dtype in zip(df.columns, df.dtypes)
         if dtype.kind in type_map
     }

--- a/tests/adapters/memory/pandas_test.py
+++ b/tests/adapters/memory/pandas_test.py
@@ -254,3 +254,29 @@ def test_get_cost(mocker: MockerFixture) -> None:
         )
         == 21931
     )
+
+
+def test_integer_column_names() -> None:
+    """
+    Test dataframes with column names that are integers.
+    """
+    mydf = pd.DataFrame(  # noqa: F841  pylint: disable=unused-variable
+        [
+            [10, 15.2, "Diamond_St"],
+            [11, 13.1, "Blacktail_Loop"],
+            [12, 13.3, "Platinum_St"],
+            [13, 12.1, "Kodiak_Trail"],
+        ],
+    )
+
+    connection = connect(":memory:")
+    cursor = connection.cursor()
+
+    sql = 'SELECT "0", "1", "2" FROM mydf'
+    cursor.execute(sql)
+    assert cursor.fetchall() == [
+        (10, 15.2, "Diamond_St"),
+        (11, 13.1, "Blacktail_Loop"),
+        (12, 13.3, "Platinum_St"),
+        (13, 12.1, "Kodiak_Trail"),
+    ]


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
