### PR TITLE
feat: stricter serialization

### DIFF
--- a/ARCHITECTURE.rst
+++ b/ARCHITECTURE.rst
@@ -90,7 +90,7 @@ These arguments will be used by ``apsw`` to instantiate the adapter later, when 
     CREATE VIRTUAL TABLE "https://api.github.com/repos/apache/superset/pulls"
       USING githubapi('repos', 'apache', 'superset', 'pulls');
 
-Except that the parameters are not passed as strings, since they can be of any type. Instead, they are first pickled and then encoded as ``base64``. This is all happens behind the scenes, both for adapter developers as for users.
+Except that the parameters are not passed as strings, since they can be of any type. Instead, they are first marshalled and then encoded as ``base64``. This is all happens behind the scenes, both for adapter developers as for users.
 
 Once the table has been created, Shillelagh will re-execute the query. The whole flow looks like this:
 

--- a/tests/adapters/api/gsheets/adapter_test.py
+++ b/tests/adapters/api/gsheets/adapter_test.py
@@ -190,7 +190,7 @@ def test_credentials() -> None:
             mock.call("BEGIN IMMEDIATE"),
             mock.call('SELECT 1 FROM "https://docs.google.com/spreadsheets/d/1"', None),
             mock.call(
-                """CREATE VIRTUAL TABLE "https://docs.google.com/spreadsheets/d/1" USING GSheetsAPI('gASVLAAAAAAAAACMKGh0dHBzOi8vZG9jcy5nb29nbGUuY29tL3NwcmVhZHNoZWV0cy9kLzGULg==', 'gAROLg==', 'gAROLg==', 'gASVEwAAAAAAAAB9lIwGc2VjcmV0lIwDWFhYlHMu', 'gASVFAAAAAAAAACMEHVzZXJAZXhhbXBsZS5jb22ULg==', 'gAROLg==', 'gASJLg==')""",
+                "CREATE VIRTUAL TABLE \"https://docs.google.com/spreadsheets/d/1\" USING GSheetsAPI('+ihodHRwczovL2RvY3MuZ29vZ2xlLmNvbS9zcHJlYWRzaGVldHMvZC8x', 'Tg==', 'Tg==', '+9oGc2VjcmV02gNYWFgw', '+hB1c2VyQGV4YW1wbGUuY29t', 'Tg==', 'Rg==')",
             ),
             mock.call('SELECT 1 FROM "https://docs.google.com/spreadsheets/d/1"', None),
         ],
@@ -223,7 +223,7 @@ def test_credentials() -> None:
             mock.call("BEGIN IMMEDIATE"),
             mock.call('SELECT 1 FROM "https://docs.google.com/spreadsheets/d/1"', None),
             mock.call(
-                "CREATE VIRTUAL TABLE \"https://docs.google.com/spreadsheets/d/1\" USING GSheetsAPI('gASVLAAAAAAAAACMKGh0dHBzOi8vZG9jcy5nb29nbGUuY29tL3NwcmVhZHNoZWV0cy9kLzGULg==', 'gAROLg==', 'gAROLg==', 'gAROLg==', 'gAROLg==', 'gAROLg==', 'gASILg==')",
+                "CREATE VIRTUAL TABLE \"https://docs.google.com/spreadsheets/d/1\" USING GSheetsAPI('+ihodHRwczovL2RvY3MuZ29vZ2xlLmNvbS9zcHJlYWRzaGVldHMvZC8x', 'Tg==', 'Tg==', 'Tg==', 'Tg==', 'Tg==', 'VA==')",
             ),
             mock.call('SELECT 1 FROM "https://docs.google.com/spreadsheets/d/1"', None),
         ],

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -292,14 +292,25 @@ def test_serialize() -> None:
     """
     Test ``serialize``.
     """
-    assert serialize(["O'Malley's"]) == "gASVEQAAAAAAAABdlIwKTydNYWxsZXknc5RhLg=="
+    assert serialize(["O'Malley's"]) == "2wEAAAD6Ck8nTWFsbGV5J3M="
+
+    def func():
+        return 42
+
+    with pytest.raises(ProgrammingError) as excinfo:
+        serialize(func)
+    assert str(excinfo.value) == (
+        f"The argument {func} is not serializable because it has type {type(func)}. "
+        "Make sure only basic types (list, dicts, strings, numbers) are passed as "
+        "arguments to adapters."
+    )
 
 
 def test_deserialize() -> None:
     """
     Test ``deserialize``.
     """
-    assert deserialize("gASVEQAAAAAAAABdlIwKTydNYWxsZXknc5RhLg==") == ["O'Malley's"]
+    assert deserialize("2wEAAAD6Ck8nTWFsbGV5J3M=") == ["O'Malley's"]
 
 
 def test_combine_args_kwargs() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Use `marshal` instead of `pickle` when serializing arguments to adapters.

A user reported an error where one of the arguments being passed was a custom class, and it caused an error during deserialization. I think it's safe to be strict here and enforce that arguments are basic types.

Now when the serialization fails we get an error message explaining the problem.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added unit test.