### PR TITLE
feat (s3_select): use available credentials

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Next
 
 - Use ``marshal`` instead of ``pickle`` for adapter argument serde (#321)
 - Support SQLAlchemy 2.0 (and 1.4) (#331)
+- ``s3_select`` can now use credentials from the environment or config files
 
 Version 1.1.5 - 2022-12-08
 ==========================

--- a/src/shillelagh/adapters/api/s3select.py
+++ b/src/shillelagh/adapters/api/s3select.py
@@ -249,12 +249,17 @@ class S3SelectAPI(Adapter):
         self.input_serialization = input_serialization
         self.table_name = path.replace("$", "S3Object")
 
+        # if credentials were passed explicitly, use them
         if aws_access_key_id and aws_secret_access_key:
             self.s3_client = boto3.client(
                 "s3",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
             )
+        # if no credentials were passed, check if they're available
+        elif boto3.session.Session().get_credentials():
+            self.s3_client = boto3.client("s3")
+        # if no credentials were found, use an anonymous client to access public buckets
         else:
             self.s3_client = boto3.client(
                 "s3",


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

If credentials are not passed explicitly to `s3_select`, use those in the environment.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added tests.