### PR TITLE
feat (generic JSON): request headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Allow specifying custom request headers when using the generic JSON adapter (#337)
+
 Version 1.2.0 - 2023-02-17
 ==========================
 

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -415,3 +415,39 @@ Note that the JSON payload should return the data as a list of dictionaries. In 
     }
 
 In the payload above the data is stored in the ``seriess`` key. In order to have Shillelagh access the data correctly you should pass a `JSONPath <https://goessner.net/articles/JsonPath/>`_ expression as an achor in the URL. For this payload the expression ``$.seriess[*]`` will return all rows inside the ``seriess`` children.
+
+If you need to authenticate you can pass custom request headers via adapter keyword arguments:
+
+.. code-block:: python
+
+    from shillelagh.backends.apsw.db import connect
+
+    connection = connect(
+        ":memory:",
+        adapter_kwargs={
+            "genericjsonapi": {
+                "request_headers": {
+                    "X-Auth-Token": "SECRET",
+                },
+            },
+        },
+    )
+
+Or via SQLAlchemy:
+
+.. code-block:: python
+
+    from sqlalchemy import create_engine
+
+    engine = create_engine(
+        "shilellagh://",
+        connect_args={
+            "adapter_kwargs": {
+                "genericjsonapi": {
+                    "request_headers": {
+                        "X-Auth-Token": "SECRET",
+                    },
+                },
+            },
+        },
+    )

--- a/tests/adapters/api/socrata_test.py
+++ b/tests/adapters/api/socrata_test.py
@@ -244,12 +244,12 @@ def test_integration(adapter_kwargs) -> None:
     cursor = connection.cursor()
 
     sql = """
-        SELECT administered_dose1_recip_4
+        SELECT administered
         FROM "https://data.cdc.gov/resource/unsk-b7fc.json"
         WHERE location = ? AND date = ?
     """
-    cursor.execute(sql, ("US", date(2021, 7, 4)))
-    assert cursor.fetchall() == [(67.1,)]
+    cursor.execute(sql, ("US", date(2023, 3, 1)))
+    assert cursor.fetchall() == [(672076105.0,)]
 
 
 def test_get_cost(mocker: MockerFixture) -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Allow specifying custom request headers when using the generic JSON adapter.

Closes https://github.com/betodealmeida/shillelagh/issues/335.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
