### PR TITLE
fix: Add separate method to escape identifiers correctly when creating virtual tables.

### DIFF
--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -39,7 +39,7 @@ from shillelagh.exceptions import (  # nopycln: import; pylint: disable=redefine
     Warning,
 )
 from shillelagh.fields import Blob, Field
-from shillelagh.lib import combine_args_kwargs, escape, find_adapter, serialize
+from shillelagh.lib import combine_args_kwargs, escape_identifier, find_adapter, serialize
 from shillelagh.types import (
     BINARY,
     DATETIME,
@@ -290,7 +290,7 @@ class Cursor:  # pylint: disable=too-many-instance-attributes
             f"'{serialize(arg)}'"
             for arg in combine_args_kwargs(adapter, *args, **kwargs)
         )
-        table_name = escape(uri)
+        table_name = escape_identifier(uri)
         self._cursor.execute(
             f'CREATE VIRTUAL TABLE "{table_name}" USING {adapter.__name__}({formatted_args})',
         )

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -39,7 +39,12 @@ from shillelagh.exceptions import (  # nopycln: import; pylint: disable=redefine
     Warning,
 )
 from shillelagh.fields import Blob, Field
-from shillelagh.lib import combine_args_kwargs, escape_identifier, find_adapter, serialize
+from shillelagh.lib import (
+    combine_args_kwargs,
+    escape_identifier,
+    find_adapter,
+    serialize,
+)
 from shillelagh.types import (
     BINARY,
     DATETIME,

--- a/src/shillelagh/lib.py
+++ b/src/shillelagh/lib.py
@@ -221,14 +221,24 @@ def update_order(
     return current_order
 
 
-def escape(value: str) -> str:
+def escape_string(value: str) -> str:
     """Escape single quotes."""
     return value.replace("'", "''")
 
 
-def unescape(value: str) -> str:
+def unescape_string(value: str) -> str:
     """Unescape single quotes."""
     return value.replace("''", "'")
+
+
+def escape_identifier(value: str) -> str:
+    """Escape double quotes."""
+    return value.replace('"', '""')
+
+
+def unescape_identifier(value: str) -> str:
+    """Unescape double quotes."""
+    return value.replace('""', '"')
 
 
 def serialize(value: Any) -> str:
@@ -247,7 +257,7 @@ def serialize(value: Any) -> str:
             "numbers) are passed as arguments to adapters.",
         ) from ex
 
-    return escape(base64.b64encode(serialized).decode())
+    return escape_string(base64.b64encode(serialized).decode())
 
 
 def deserialize(value: str) -> Any:
@@ -257,7 +267,7 @@ def deserialize(value: str) -> Any:
     This function is used by the SQLite backend, in order to deserialize
     the virtual table definition and instantiate an adapter.
     """
-    return marshal.loads(base64.b64decode(unescape(value).encode()))
+    return marshal.loads(base64.b64decode(unescape_string(value).encode()))
 
 
 def build_sql(  # pylint: disable=too-many-locals, too-many-arguments, too-many-branches

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -296,8 +296,10 @@ def test_escape_identifier() -> None:
     """
     assert escape_identifier("1") == "1"
     assert escape_identifier("O'Malley's") == "O'Malley's"
-    assert escape_identifier(
-        'a dove called: "Who? who? who?"') == 'a dove called: ""Who? who? who?""'
+    assert (
+        escape_identifier('a dove called: "Who? who? who?"')
+        == 'a dove called: ""Who? who? who?""'
+    )
 
 
 def test_unescape_identifier() -> None:
@@ -306,8 +308,10 @@ def test_unescape_identifier() -> None:
     """
     assert unescape_identifier("1") == "1"
     assert unescape_identifier("O''Malley''s") == "O''Malley''s"
-    assert unescape_identifier(
-        'a dove called: ""Who? who? who?""') == 'a dove called: "Who? who? who?"'
+    assert (
+        unescape_identifier('a dove called: ""Who? who? who?""')
+        == 'a dove called: "Who? who? who?"'
+    )
 
 
 def test_serialize() -> None:
@@ -473,4 +477,3 @@ def test_apply_limit_and_offset() -> None:
 
     rows = apply_limit_and_offset(iter(range(10)), offset=2)
     assert list(rows) == [2, 3, 4, 5, 6, 7, 8, 9]
-

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -26,13 +26,15 @@ from shillelagh.lib import (
     build_sql,
     combine_args_kwargs,
     deserialize,
-    escape,
+    escape_identifier,
+    escape_string,
     filter_data,
     find_adapter,
     is_not_null,
     is_null,
     serialize,
-    unescape,
+    unescape_identifier,
+    unescape_string,
     update_order,
 )
 from shillelagh.typing import RequestedOrder
@@ -272,20 +274,40 @@ def test_build_sql_impossible() -> None:
         build_sql(columns, {"a": Impossible()}, [])
 
 
-def test_escape() -> None:
+def test_escape_string() -> None:
     """
-    Test ``escape``.
+    Test ``escape_string``.
     """
-    assert escape("1") == "1"
-    assert escape("O'Malley's") == "O''Malley''s"
+    assert escape_string("1") == "1"
+    assert escape_string("O'Malley's") == "O''Malley''s"
 
 
-def test_unescape() -> None:
+def test_unescape_string() -> None:
     """
-    Test ``unescape``.
+    Test ``unescape_string``.
     """
-    assert unescape("1") == "1"
-    assert unescape("O''Malley''s") == "O'Malley's"
+    assert unescape_string("1") == "1"
+    assert unescape_string("O''Malley''s") == "O'Malley's"
+
+
+def test_escape_identifier() -> None:
+    """
+    Test ``escape_identifier``.
+    """
+    assert escape_identifier("1") == "1"
+    assert escape_identifier("O'Malley's") == "O'Malley's"
+    assert escape_identifier(
+        'a dove called: "Who? who? who?"') == 'a dove called: ""Who? who? who?""'
+
+
+def test_unescape_identifier() -> None:
+    """
+    Test ``unescape_identifier``.
+    """
+    assert unescape_identifier("1") == "1"
+    assert unescape_identifier("O''Malley''s") == "O''Malley''s"
+    assert unescape_identifier(
+        'a dove called: ""Who? who? who?""') == 'a dove called: "Who? who? who?"'
 
 
 def test_serialize() -> None:
@@ -451,3 +473,4 @@ def test_apply_limit_and_offset() -> None:
 
     rows = apply_limit_and_offset(iter(range(10)), offset=2)
     assert list(rows) == [2, 3, 4, 5, 6, 7, 8, 9]
+


### PR DESCRIPTION
# Summary
Fixes #338 

When virtual tables were added/created, they were incorrectly escaped. 
This adds a new escape method for table identifier (as suggested in the linked issue) and renames the old one.

# Testing instructions
Added unit tests for the new identifier escape method.
