### PR TITLE
feat: support best index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next
 - Allow specifying custom request headers when using the generic JSON adapter (#337)
 - Fix for escaping identifiers correctly (#340)
 - Support for S3-compatible storage (#343)
+- Adapters can now know which columns were requested (#345)
 
 Version 1.2.0 - 2023-02-17
 ==========================

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -296,6 +296,29 @@ If an adapter declares support for ``LIMIT`` and ``OFFSET`` a corresponding para
 
 Now the adapter can handle ``limit`` and ``offset``, reducing the amount of data that is returned. Note that even if the adapter declares supporting ``LIMIT``, SQLite will still enforce the limit, ie, if for any reason the adapter returns more rows than the limit SQLite will fix the problem. The same is not true for the offset.
 
+Returning only the requested columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default adapters should return all the columns available, since they have no information on which columns are actually needed. Starting with apsw `apsw 3.41.0.0 <https://github.com/rogerbinns/apsw/releases/tag/3.41.0.0>`_ adapters can optionally receive only the requested columns in their ``get_rows`` and ``get_data`` methods. The adapter must declare support for it by setting the attribute ``supports_bestindex`` to true:
+
+.. code-block:: python
+
+    class WeatherAPI(Adapter):
+
+        supports_bestindex = True
+
+Then the ``requested_columns: Optional[Set[str]]`` argument will be passed to ``get_rows`` and ``get_data``:
+
+.. code-block:: python
+
+    def get_rows(
+        self,
+        bounds: Dict[str, Filter],
+        order: List[Tuple[str, RequestedOrder]],
+        requested_columns: Optional[Set[str]] = None,
+        **kwargs: Any,
+    ) -> Iterator[Dict[str, Any]]:
+
 A read-write adapter
 ====================
 

--- a/examples/generic_json.py
+++ b/examples/generic_json.py
@@ -49,8 +49,10 @@ if __name__ == "__main__":
     cursor = connection.cursor()
 
     SQL = """
-    SELECT * FROM
+    SELECT domain, isDead FROM
     "https://api.domainsdb.info/v1/domains/search?domain=facebook&zone=com#$.domains[*]"
+    WHERE isDead > 2
+    ORDER BY domain DESC
     LIMIT 2
     """
     for row in cursor.execute(SQL):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,8 @@ greenlet==1.1.2
     # via sqlalchemy
 idna==3.3
     # via requests
+packaging==23.0
+    # via shillelagh
 python-dateutil==2.8.2
     # via shillelagh
 requests==2.28.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,6 +89,7 @@ packaging==21.3
     # via
     #   build
     #   pytest
+    #   shillelagh
 pandas==1.4.3
     # via shillelagh
 pep517==0.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     requests>=2.25.1
     sqlalchemy>=1.3
     typing_extensions>=3.7.4.3
+    packaging
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -48,6 +48,9 @@ class Adapter:
     supports_limit = False
     supports_offset = False
 
+    # if true, the requested columns will be passed to ``get_rows`` and ``get_data``
+    supports_bestindex = False
+
     def __init__(self, *args: Any, **kwargs: Any):  # pylint: disable=unused-argument
         # ensure ``self.close`` gets called before GC
         atexit.register(self.close)

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 import apsw
+from packaging.version import Version
 
 from shillelagh import functions
 from shillelagh.adapters.base import Adapter
@@ -447,7 +448,14 @@ class Connection:
 
         # register adapters
         for adapter in adapters:
-            self._connection.createmodule(adapter.__name__, VTModule(adapter))
+            if Version(apsw.apswversion()) >= Version("3.41.0.0"):
+                self._connection.createmodule(
+                    adapter.__name__,
+                    VTModule(adapter),
+                    use_bestindex_object=adapter.supports_bestindex,
+                )
+            else:
+                self._connection.createmodule(adapter.__name__, VTModule(adapter))
         self._adapters = adapters
         self._adapter_kwargs = adapter_kwargs
 

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -95,6 +95,7 @@ def test_virtual_best_index() -> None:
             (2, apsw.SQLITE_INDEX_CONSTRAINT_GT),  # pets >
             (0, apsw.SQLITE_INDEX_CONSTRAINT_LE),  # age <=
             (-1, 73),  # LIMIT
+            (-1, apsw.SQLITE_INDEX_CONSTRAINT_LE),  # INVALID, just for coverage
         ],
         [(1, False)],  # ORDER BY name ASC
     )
@@ -109,6 +110,57 @@ def test_virtual_best_index() -> None:
         True,
         666,
     )
+
+
+def test_virtual_best_index_object(mocker: MockerFixture) -> None:
+    """
+    Test ``BestIndexObject``.
+    """
+    index_info = mocker.MagicMock()
+    index_info.colUsed = {0, 2}
+    index_info_to_dict = mocker.patch("shillelagh.backends.apsw.vt.index_info_to_dict")
+    index_info_to_dict.return_value = {
+        "aConstraint": [
+            {"iColumn": 1, "op": apsw.SQLITE_INDEX_CONSTRAINT_EQ},
+            {"iColumn": 2, "op": apsw.SQLITE_INDEX_CONSTRAINT_GT},
+            {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_LE},
+            {"op": 73},
+        ],
+        "aOrderBy": [{"iColumn": 1, "desc": False}],
+    }
+
+    adapter = FakeAdapter()
+    adapter.supports_limit = True
+
+    table = VTTable(adapter)
+    assert table.requested_columns is None
+
+    result = table.BestIndexObject(index_info)
+    assert result is True
+    assert table.requested_columns == {"age", "pets"}
+
+    index_info.set_aConstraintUsage_argvIndex.assert_has_calls(
+        [
+            mocker.call(0, 0),
+            mocker.call(2, 1),
+            mocker.call(3, 2),
+        ],
+    )
+    index_info.set_aConstraintUsage_omit.assert_has_calls(
+        [
+            mocker.call(0, True),
+            mocker.call(2, True),
+            mocker.call(3, True),
+        ],
+    )
+    assert index_info.idxNum == 42
+    assert index_info.idxStr == (
+        f"[[[1, {apsw.SQLITE_INDEX_CONSTRAINT_EQ}], "
+        f"[0, {apsw.SQLITE_INDEX_CONSTRAINT_LE}], [-1, 73]], "
+        "[[1, false]]]"
+    )
+    assert index_info.orderByConsumed is True
+    assert index_info.estimatedCost == 666
 
 
 def test_virtual_best_index_static_order_not_consumed() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Initial support for https://github.com/betodealmeida/shillelagh/issues/344. I'll add estimated rows in a separate PR.

Closes https://github.com/betodealmeida/shillelagh/issues/293

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Added unit tests.
