### PR TITLE
fix: error loading adapters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next
 - Support for S3-compatible storage (#343)
 - Adapters can now know which columns were requested (#345)
 - Python 3.11 officially supported (#334)
+- Fix for error when an adapater can't be loaded (#346)
 
 Version 1.2.0 - 2023-02-17
 ==========================

--- a/tests/adapters/registry_test.py
+++ b/tests/adapters/registry_test.py
@@ -73,5 +73,6 @@ def test_load_only_requested_adapters(registry: AdapterLoader) -> None:
 
     assert registry.load_all(["valid"]) == {"valid": FakeAdapter}
     with pytest.raises(InterfaceError) as excinfo:
-        registry.load_all()
+        registry.load_all(["valid", "invalid"])
     assert str(excinfo.value) == "Unable to load adapter invalid"
+    assert registry.load_all() == {"valid": FakeAdapter}

--- a/tests/backends/apsw/db_test.py
+++ b/tests/backends/apsw/db_test.py
@@ -10,9 +10,9 @@ import apsw
 import pytest
 from pytest_mock import MockerFixture
 
-from shillelagh.adapters.registry import AdapterLoader
+from shillelagh.adapters.registry import AdapterLoader, UnsafeAdaptersError
 from shillelagh.backends.apsw.db import Connection, connect, convert_binding
-from shillelagh.exceptions import InterfaceError, NotSupportedError, ProgrammingError
+from shillelagh.exceptions import NotSupportedError, ProgrammingError
 from shillelagh.fields import Float, String, StringInteger
 
 from ...fakes import FakeAdapter
@@ -178,7 +178,7 @@ def test_connect_safe(mocker: MockerFixture, registry: AdapterLoader) -> None:
     registry.clear()
     registry.add("one", FakeAdapter1)
     registry.add("one", FakeAdapter2)
-    with pytest.raises(InterfaceError) as excinfo:
+    with pytest.raises(UnsafeAdaptersError) as excinfo:
         connect(":memory:", ["one"], safe=True)
     assert str(excinfo.value) == "Multiple adapters found with name one"
 


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Closes https://github.com/betodealmeida/shillelagh/issues/341.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->

Updated unit tests.