### PR TITLE
fix: BestIndexObject index

### DIFF
--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -436,7 +436,7 @@ class VTTable:
 
         for i, constraint in enumerate(constraints_used):
             if isinstance(constraint, tuple):
-                index_info.set_aConstraintUsage_argvIndex(i, constraint[0])
+                index_info.set_aConstraintUsage_argvIndex(i, constraint[0] + 1)
                 index_info.set_aConstraintUsage_omit(i, constraint[1])
         index_info.idxNum = index_number
         index_info.idxStr = index_name

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -141,9 +141,9 @@ def test_virtual_best_index_object(mocker: MockerFixture) -> None:
 
     index_info.set_aConstraintUsage_argvIndex.assert_has_calls(
         [
-            mocker.call(0, 0),
-            mocker.call(2, 1),
-            mocker.call(3, 2),
+            mocker.call(0, 1),
+            mocker.call(2, 2),
+            mocker.call(3, 3),
         ],
     )
     index_info.set_aConstraintUsage_omit.assert_has_calls(


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

See https://github.com/betodealmeida/shillelagh/issues/344#issuecomment-1499717353.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
