### PR TITLE
feat: support WHERE x IN (list) clauses with multiple items in list

### DIFF
--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -81,7 +81,7 @@ class Adapter:
             return None
         if not isinstance(a_set, set):
             raise TypeError("serialize_set(): a_set must be a set")
-        return f"set({json.dumps(list([item for item in a_set]))})"
+        return f"set({json.dumps(list(a_set))})"
 
     def deserialize_set(self, a_set_str: Any) -> Any:
         """Deserialize the given string to a set.
@@ -104,10 +104,10 @@ class Adapter:
             return None
         if not isinstance(a_set_str, str):
             raise TypeError("deserialize_set(): a_set_str must be a string")
-        m = re.match(r"set\((.*)\)", a_set_str)
-        if not m:
+        match = re.match(r"set\((.*)\)", a_set_str)
+        if not match:
             return set([a_set_str])
-        return set(json.loads(m.group(1)))
+        return set(json.loads(match.group(1)))
 
     @staticmethod
     def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -63,53 +63,6 @@ class Adapter:
         atexit.register(self.close)
 
     @staticmethod
-    def serialize_set(a_set: Any) -> Any:
-        """Serialize the given set to a string.
-
-        This will convert a given set {'a', 'b', 'c'} to the string: "set(['a','b','c'])"
-
-        Args:
-            a_set (Any): A set (of strings) or None.
-
-        Raises:
-            TypeError: If anything but a set or None is given to this method.
-
-        Returns:
-            Any: A string representation of the set or None.
-        """
-        if a_set is None:
-            return None
-        if not isinstance(a_set, set):
-            raise TypeError("serialize_set(): a_set must be a set")
-        return f"set({json.dumps(list(a_set))})"
-
-    def deserialize_set(self, a_set_str: Any) -> Any:
-        """Deserialize the given string to a set.
-
-        This will convert a given "set(['a','b','c'])" string to the set {'a', 'b', 'c'}
-        If a string is passed which does not match the /set(.*)/ regular expression, then the
-        string is simply returned in a set with that string as single entry.
-
-        Args:
-            a_set_str (Any): A serialized string or None.
-
-        Raises:
-            TypeError: If anything but a string or None is given to this method.
-
-        Returns:
-            Any: The deserialized list as a set if the input was a previously serialized set.
-            A string entry is also converted to a single entry set.
-        """
-        if a_set_str is None:
-            return None
-        if not isinstance(a_set_str, str):
-            raise TypeError("deserialize_set(): a_set_str must be a string")
-        match = re.match(r"set\((.*)\)", a_set_str)
-        if not match:
-            return set([a_set_str])
-        return set(json.loads(match.group(1)))
-
-    @staticmethod
     def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
         """
         Return if a given table is supported by the adapter.

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -51,9 +51,9 @@ class Adapter:
     # if true, the requested columns will be passed to ``get_rows`` and ``get_data``
     supports_requested_columns = False
 
-    # if true, a set of strings from an in statement will be serialized before being
-    # passed in as bounds to ``get_rows`` and ``get_data``. This requires
-    # supports_requested_columns to be set to True as well.
+    # if true, a set from an IN statement will be assigned the new IN operator and
+    # passed in as a tuple to bounds in ``get_rows`` and ``get_data``. This requires
+    # supports_requested_columns to be set to true as well.
     supports_in_statements = False
 
     def __init__(self, *args: Any, **kwargs: Any):  # pylint: disable=unused-argument

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -63,16 +63,19 @@ class Adapter:
         atexit.register(self.close)
 
     @staticmethod
-    def serialize_set(a_set: set | None) -> str | None:
-        """Serialize the given set (or string) to a string.
+    def serialize_set(a_set: Any) -> Any:
+        """Serialize the given set to a string.
 
         This will convert a given set {'a', 'b', 'c'} to the string: "set(['a','b','c'])"
 
         Args:
-            a_set (set): A set (strings).
+            a_set (Any): A set (of strings) or None.
+
+        Raises:
+            TypeError: If anything but a set or None is given to this method.
 
         Returns:
-            str | None: A string representation of the set.
+            Any: A string representation of the set or None.
         """
         if a_set is None:
             return None
@@ -80,19 +83,22 @@ class Adapter:
             raise TypeError("serialize_set(): a_set must be a set")
         return f"set({json.dumps(list([item for item in a_set]))})"
 
-    def deserialize_set(self, a_set_str: str | None) -> set | None:
+    def deserialize_set(self, a_set_str: Any) -> Any:
         """Deserialize the given string to a set.
 
         This will convert a given "set(['a','b','c'])" string to the set {'a', 'b', 'c'}
         If a string is passed which does not match the /set(.*)/ regular expression, then the
-        string is converted to a set with the string as single element. This
-
+        string is simply returned as a string.
 
         Args:
-            a_set_str (str | None): A serialized string.
+            a_set_str (Any): A serialized string or None.
+
+        Raises:
+            TypeError: If anything but a string or None is given to this method.
 
         Returns:
-            set | None: The deserialized list as a set.
+            Any: The deserialized list as a set if the input was a previously serialized set.
+            Otherwise the string (or None) is simply returned.
         """
         if a_set_str is None:
             return None

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -1,6 +1,8 @@
 """Base class for adapters."""
 import atexit
 import inspect
+import json
+import re
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from shillelagh.exceptions import NotSupportedError
@@ -51,9 +53,55 @@ class Adapter:
     # if true, the requested columns will be passed to ``get_rows`` and ``get_data``
     supports_requested_columns = False
 
+    # if true, a set of strings from an in statement will be serialized before being
+    # passed in as bounds to ``get_rows`` and ``get_data``. This requires
+    # supports_requested_columns to be set to True as well.
+    supports_in_statements = False
+
     def __init__(self, *args: Any, **kwargs: Any):  # pylint: disable=unused-argument
         # ensure ``self.close`` gets called before GC
         atexit.register(self.close)
+
+    @staticmethod
+    def serialize_set(a_set: set | None) -> str | None:
+        """Serialize the given set (or string) to a string.
+
+        This will convert a given set {'a', 'b', 'c'} to the string: "set(['a','b','c'])"
+
+        Args:
+            a_set (set): A set (strings).
+
+        Returns:
+            str | None: A string representation of the set.
+        """
+        if a_set is None:
+            return None
+        if not isinstance(a_set, set):
+            raise TypeError("serialize_set(): a_set must be a set")
+        return f"set({json.dumps(list([item for item in a_set]))})"
+
+    def deserialize_set(self, a_set_str: str | None) -> set | None:
+        """Deserialize the given string to a set.
+
+        This will convert a given "set(['a','b','c'])" string to the set {'a', 'b', 'c'}
+        If a string is passed which does not match the /set(.*)/ regular expression, then the
+        string is converted to a set with the string as single element. This
+
+
+        Args:
+            a_set_str (str | None): A serialized string.
+
+        Returns:
+            set | None: The deserialized list as a set.
+        """
+        if a_set_str is None:
+            return None
+        if not isinstance(a_set_str, str):
+            raise TypeError("deserialize_set(): a_set_str must be a string")
+        m = re.match(r"set\((.*)\)", a_set_str)
+        if not m:
+            return a_set_str
+        return set(json.loads(m.group(1)))
 
     @staticmethod
     def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -88,7 +88,7 @@ class Adapter:
 
         This will convert a given "set(['a','b','c'])" string to the set {'a', 'b', 'c'}
         If a string is passed which does not match the /set(.*)/ regular expression, then the
-        string is simply returned as a string.
+        string is simply returned in a set with that string as single entry.
 
         Args:
             a_set_str (Any): A serialized string or None.
@@ -98,7 +98,7 @@ class Adapter:
 
         Returns:
             Any: The deserialized list as a set if the input was a previously serialized set.
-            Otherwise the string (or None) is simply returned.
+            A string entry is also converted to a single entry set.
         """
         if a_set_str is None:
             return None
@@ -106,7 +106,7 @@ class Adapter:
             raise TypeError("deserialize_set(): a_set_str must be a string")
         m = re.match(r"set\((.*)\)", a_set_str)
         if not m:
-            return a_set_str
+            return set([a_set_str])
         return set(json.loads(m.group(1)))
 
     @staticmethod

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -1,8 +1,6 @@
 """Base class for adapters."""
 import atexit
 import inspect
-import json
-import re
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from shillelagh.exceptions import NotSupportedError

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -192,8 +192,8 @@ def get_all_bounds(
 
         # convert constraint to native Python type, then to DB specific type
         if isinstance(constraint, set):
-            # A WHERE x IN (list) clause sends in constraintargs as a set when N>1: {item1,...,itemN}.
-            # We serialize this set to a string '["item1",...,"itemN"]'.
+            # A WHERE x IN (list) clause sends in constraintargs as a set when N>1:
+            # {item1,...,itemN}. We serialize this set to a string '["item1",...,"itemN"]'.
             constraint = json.dumps(list(constraint))
         constraint = type_map[column_type.type]().parse(constraint)
         value = column_type.format(constraint)

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -192,9 +192,9 @@ def get_all_bounds(
 
         # convert constraint to native Python type, then to DB specific type
         if isinstance(constraint, set):
-            # A WHERE x IN (list) clause sends in constraintargs as a set: {item1,...,itemN}
-            # We serialize this to "set([item1,...,itemN])".
-            constraint = Adapter.serialize_set(constraint)
+            # A WHERE x IN (list) clause sends in constraintargs as a set when N>1: {item1,...,itemN}.
+            # We serialize this set to a string '["item1",...,"itemN"]'.
+            constraint = json.dumps(list(constraint))
         constraint = type_map[column_type.type]().parse(constraint)
         value = column_type.format(constraint)
 

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -190,16 +190,18 @@ def get_all_bounds(
         column_name = column_names[column_index]
         column_type = columns[column_name]
 
-        if isinstance(constraint, set) and operator == Operator.EQ:
+        value: Any
+        if isinstance(constraint, set) and operator is Operator.EQ:
             # See also https://rogerbinns.github.io/apsw/vtable.html#apsw.VTCursor.Filter
             constraint = [type_map[column_type.type]().parse(c) for c in constraint]
-            tuple_value = tuple(column_type.format(c) for c in constraint)
-            all_bounds[column_name].add((Operator.IN, tuple_value))
+            value = tuple(column_type.format(c) for c in constraint)
+            operator = Operator.IN
         else:
             # convert constraint to native Python type, then to DB specific type
             constraint = type_map[column_type.type]().parse(constraint)
             value = column_type.format(constraint)
-            all_bounds[column_name].add((operator, value))
+
+        all_bounds[column_name].add((operator, value))
 
     return all_bounds
 

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -444,7 +444,11 @@ class VTTable:
             if isinstance(constraint, tuple):
                 index_info.set_aConstraintUsage_argvIndex(i, constraint[0] + 1)
                 index_info.set_aConstraintUsage_omit(i, constraint[1])
-                if self.adapter.supports_in_statements and index_info.get_aConstraintUsage_in(i):
+                if (
+                    self.adapter.supports_in_statements and
+                    index_info.get_aConstraint_op(i) == apsw.SQLITE_INDEX_CONSTRAINT_EQ and
+                    index_info.get_aConstraintUsage_in(i)
+                ):
                     # Explicit request to pass the IN (list) as a set in the constraintargs.
                     index_info.set_aConstraintUsage_in(i, True)
         index_info.idxNum = index_number

--- a/src/shillelagh/filters.py
+++ b/src/shillelagh/filters.py
@@ -22,6 +22,7 @@ class Operator(Enum):
     LIKE = "LIKE"
     LIMIT = "LIMIT"
     OFFSET = "OFFSET"
+    IN = "IN"
 
 
 class Side(Enum):
@@ -425,3 +426,36 @@ class Range(Filter):
             operator = "<=" if self.include_end else "<"
             comparisons.append(f"{operator}{self.end}")
         return ",".join(comparisons)
+
+
+class In(Filter):
+    """
+    Substring searches.
+    """
+
+    operators: Set[Operator] = {
+        Operator.IN,
+    }
+
+    def __init__(self, value: Any):
+        self.value = value
+
+    @classmethod
+    def build(cls, operations: Set[Tuple[Operator, Any]]) -> Filter:
+        # we only accept a single value
+        values = {value for operator, value in operations}
+        if len(values) != 1:
+            return Impossible()
+
+        # we only accept tuples
+        value = values.pop()
+        if not isinstance(value, tuple):
+            return Impossible()
+
+        return cls(value)
+
+    def check(self, value: Any) -> bool:
+        return bool(value in self.value)
+
+    def __repr__(self) -> str:
+        return f"IN{self.value}"

--- a/src/shillelagh/filters.py
+++ b/src/shillelagh/filters.py
@@ -430,7 +430,9 @@ class Range(Filter):
 
 class In(Filter):
     """
-    Substring searches.
+    Filter for a list of choice items.
+
+    The value is a tuple of items, one of which must match to pass.
     """
 
     operators: Set[Operator] = {
@@ -447,15 +449,10 @@ class In(Filter):
         if len(values) != 1:
             return Impossible()
 
-        # we only accept tuples
-        value = values.pop()
-        if not isinstance(value, tuple):
-            return Impossible()
-
-        return cls(value)
+        return cls(values.pop())
 
     def check(self, value: Any) -> bool:
-        return bool(value in self.value)
+        return value in self.value
 
     def __repr__(self) -> str:
         return f"IN{self.value}"

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -21,7 +21,7 @@ from shillelagh.backends.apsw.vt import (
 )
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Field, Float, Integer, Order, String
-from shillelagh.filters import Equal, Operator
+from shillelagh.filters import Equal, In, Operator
 
 from ...fakes import FakeAdapter
 
@@ -67,6 +67,18 @@ class FakeAdapterNoColumns(FakeAdapter):
 
     def get_columns(self) -> Dict[str, Field]:
         return {}
+
+
+class FakeAdapterInStatements(FakeAdapter):
+
+    """
+    An adapter with In filter suppoort.
+    """
+    supports_requested_columns = True
+    supports_in_statements = True
+    supports_limit = False
+    supports_offset = False
+    name = String(filters=[Equal, In], order=Order.ANY, exact=True)
 
 
 def test_vt_module() -> None:
@@ -126,8 +138,16 @@ def test_virtual_best_index_object(mocker: MockerFixture) -> None:
             {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_LE},
             {"op": 73},
         ],
+        "aConstraintUsage": [
+            {'argvIndex': 0, 'omit': False, 'in': True},
+            {'argvIndex': 0, 'omit': False, 'in': False},
+            {'argvIndex': 0, 'omit': False, 'in': False},
+        ],
         "aOrderBy": [{"iColumn": 1, "desc": False}],
     }
+    def get_a_constraint_usage_in(i):
+        return index_info_to_dict.return_value["aConstraintUsage"][i]["in"]
+    index_info.get_aConstraintUsage_in = get_a_constraint_usage_in
 
     adapter = FakeAdapter()
     adapter.supports_limit = True
@@ -153,10 +173,72 @@ def test_virtual_best_index_object(mocker: MockerFixture) -> None:
             mocker.call(3, True),
         ],
     )
+    assert len(index_info.method_calls) == 6
     assert index_info.idxNum == 42
     assert index_info.idxStr == (
         f"[[[1, {apsw.SQLITE_INDEX_CONSTRAINT_EQ}], "
         f"[0, {apsw.SQLITE_INDEX_CONSTRAINT_LE}], [-1, 73]], "
+        "[[1, false]]]"
+    )
+    assert index_info.orderByConsumed is True
+    assert index_info.estimatedCost == 666
+
+
+def test_virtual_best_index_object_with_in_statement(mocker: MockerFixture) -> None:
+    """
+    Test ``BestIndexObject``.
+    """
+    index_info = mocker.MagicMock()
+    index_info.colUsed = {0, 2}
+    index_info_to_dict = mocker.patch("shillelagh.backends.apsw.vt.index_info_to_dict")
+    index_info_to_dict.return_value = {
+        "aConstraint": [
+            {"iColumn": 1, "op": apsw.SQLITE_INDEX_CONSTRAINT_EQ},
+            {"iColumn": 2, "op": apsw.SQLITE_INDEX_CONSTRAINT_GT},
+            {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_LE},
+            {"op": 73},
+        ],
+        "aConstraintUsage": [
+            {'argvIndex': 0, 'omit': False, 'in': True},
+            {'argvIndex': 0, 'omit': False, 'in': False},
+            {'argvIndex': 0, 'omit': False, 'in': False},
+        ],
+        "aOrderBy": [{"iColumn": 1, "desc": False}],
+    }
+    def get_a_constraint_usage_in(i):
+        return index_info_to_dict.return_value["aConstraintUsage"][i]["in"]
+    index_info.get_aConstraintUsage_in = get_a_constraint_usage_in
+
+    adapter = FakeAdapterInStatements()
+
+    table = VTTable(adapter)
+    assert table.requested_columns is None
+
+    result = table.BestIndexObject(index_info)
+    assert result is True
+    assert table.requested_columns == {"age", "pets"}
+
+    index_info.set_aConstraintUsage_argvIndex.assert_has_calls(
+        [
+            mocker.call(0, 1),
+            mocker.call(2, 2),
+        ],
+    )
+    index_info.set_aConstraintUsage_omit.assert_has_calls(
+        [
+            mocker.call(0, True),
+            mocker.call(2, True),
+        ],
+    )
+    index_info.set_aConstraintUsage_in.assert_has_calls(
+        [
+            mocker.call(0, True),
+        ],
+    )
+    assert index_info.idxNum == 42
+    assert index_info.idxStr == (
+        f"[[[1, {apsw.SQLITE_INDEX_CONSTRAINT_EQ}], "
+        f"[0, {apsw.SQLITE_INDEX_CONSTRAINT_LE}]], "
         "[[1, false]]]"
     )
     assert index_info.orderByConsumed is True
@@ -540,6 +622,23 @@ def test_get_all_bounds() -> None:
 
     assert get_all_bounds(indexes, constraintargs, columns) == {
         "a": {(Operator.EQ, "test")},
+    }
+
+
+def test_get_all_bounds_in_statements() -> None:
+    """
+    Test ``get_all_bounds`` for IN statements.
+    """
+    indexes = [
+        (-1, 73),  # LIMIT
+        (-1, 74),  # OFFSET
+        (0, 2),  # EQ
+    ]
+    constraintargs = [10, 5, {"test1", "test2"}]
+    columns: Dict[str, Field] = {"a": String()}
+
+    assert get_all_bounds(indexes, constraintargs, columns) == {
+        "a": {(Operator.IN, ('test1', 'test2'))},
     }
 
 

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -207,7 +207,10 @@ def test_virtual_best_index_object_with_in_statement(mocker: MockerFixture) -> N
     }
     def get_a_constraint_usage_in(i):
         return index_info_to_dict.return_value["aConstraintUsage"][i]["in"]
+    def get_a_constraint_op(i):
+        return index_info_to_dict.return_value["aConstraint"][i]["op"]
     index_info.get_aConstraintUsage_in = get_a_constraint_usage_in
+    index_info.get_aConstraint_op = get_a_constraint_op
 
     adapter = FakeAdapterInStatements()
 
@@ -638,7 +641,7 @@ def test_get_all_bounds_in_statements() -> None:
     columns: Dict[str, Field] = {"a": String()}
 
     assert get_all_bounds(indexes, constraintargs, columns) == {
-        "a": {(Operator.IN, ('test1', 'test2'))},
+        "a": {(Operator.IN, ('test2', 'test1'))},
     }
 
 

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -640,9 +640,11 @@ def test_get_all_bounds_in_statements() -> None:
     constraintargs = [10, 5, {"test1", "test2"}]
     columns: Dict[str, Field] = {"a": String()}
 
-    assert get_all_bounds(indexes, constraintargs, columns) == {
+    assert get_all_bounds(indexes, constraintargs, columns) in [{
         "a": {(Operator.IN, ('test2', 'test1'))},
-    }
+    }, {
+        "a": {(Operator.IN, ('test1', 'test2'))},
+    },]
 
 
 def test_get_limit_offset() -> None:

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -74,6 +74,7 @@ class FakeAdapterInStatements(FakeAdapter):
     """
     An adapter with In filter suppoort.
     """
+
     supports_requested_columns = True
     supports_in_statements = True
     supports_limit = False
@@ -139,14 +140,16 @@ def test_virtual_best_index_object(mocker: MockerFixture) -> None:
             {"op": 73},
         ],
         "aConstraintUsage": [
-            {'argvIndex': 0, 'omit': False, 'in': True},
-            {'argvIndex': 0, 'omit': False, 'in': False},
-            {'argvIndex': 0, 'omit': False, 'in': False},
+            {"argvIndex": 0, "omit": False, "in": True},
+            {"argvIndex": 0, "omit": False, "in": False},
+            {"argvIndex": 0, "omit": False, "in": False},
         ],
         "aOrderBy": [{"iColumn": 1, "desc": False}],
     }
+
     def get_a_constraint_usage_in(i):
         return index_info_to_dict.return_value["aConstraintUsage"][i]["in"]
+
     index_info.get_aConstraintUsage_in = get_a_constraint_usage_in
 
     adapter = FakeAdapter()
@@ -199,16 +202,19 @@ def test_virtual_best_index_object_with_in_statement(mocker: MockerFixture) -> N
             {"op": 73},
         ],
         "aConstraintUsage": [
-            {'argvIndex': 0, 'omit': False, 'in': True},
-            {'argvIndex': 0, 'omit': False, 'in': False},
-            {'argvIndex': 0, 'omit': False, 'in': False},
+            {"argvIndex": 0, "omit": False, "in": True},
+            {"argvIndex": 0, "omit": False, "in": False},
+            {"argvIndex": 0, "omit": False, "in": False},
         ],
         "aOrderBy": [{"iColumn": 1, "desc": False}],
     }
+
     def get_a_constraint_usage_in(i):
         return index_info_to_dict.return_value["aConstraintUsage"][i]["in"]
+
     def get_a_constraint_op(i):
         return index_info_to_dict.return_value["aConstraint"][i]["op"]
+
     index_info.get_aConstraintUsage_in = get_a_constraint_usage_in
     index_info.get_aConstraint_op = get_a_constraint_op
 
@@ -640,11 +646,14 @@ def test_get_all_bounds_in_statements() -> None:
     constraintargs = [10, 5, {"test1", "test2"}]
     columns: Dict[str, Field] = {"a": String()}
 
-    assert get_all_bounds(indexes, constraintargs, columns) in [{
-        "a": {(Operator.IN, ('test2', 'test1'))},
-    }, {
-        "a": {(Operator.IN, ('test1', 'test2'))},
-    },]
+    assert get_all_bounds(indexes, constraintargs, columns) in [
+        {
+            "a": {(Operator.IN, ("test2", "test1"))},
+        },
+        {
+            "a": {(Operator.IN, ("test1", "test2"))},
+        },
+    ]
 
 
 def test_get_limit_offset() -> None:

--- a/tests/filters_test.py
+++ b/tests/filters_test.py
@@ -406,7 +406,7 @@ def test_in_check_strings() -> None:
     assert filter_.check('a')
     assert filter_.check('b')
     assert not filter_.check('c')
-    assert str(filter_) == "IN('a', 'b')"
+    assert str(filter_) == "IN('b', 'a')"
 
 def test_in_multiple_value_impossible() -> None:
     """

--- a/tests/filters_test.py
+++ b/tests/filters_test.py
@@ -406,7 +406,10 @@ def test_in_check_strings() -> None:
     assert filter_.check('a')
     assert filter_.check('b')
     assert not filter_.check('c')
-    assert str(filter_) == "IN('b', 'a')"
+    assert str(filter_) in [
+        "IN('b', 'a')",
+        "IN('a', 'b')",
+    ]
 
 def test_in_multiple_value_impossible() -> None:
     """

--- a/tests/filters_test.py
+++ b/tests/filters_test.py
@@ -7,6 +7,7 @@ from shillelagh.filters import (
     Endpoint,
     Equal,
     Impossible,
+    In,
     IsNotNull,
     IsNull,
     Like,
@@ -385,3 +386,35 @@ def test_is_not_null() -> None:
     assert IsNotNull.build([]) == IsNotNull()  # type: ignore
     assert IsNotNull().check(None) is False
     assert IsNotNull() != 0
+
+def test_in_numbers() -> None:
+    """
+    Test ``In``.
+    """
+    operations = {(Operator.IN, tuple({0, 1, 5}))}
+    filter_ = In.build(operations)
+    assert isinstance(filter_, In)
+    assert str(filter_) == "IN(0, 1, 5)"
+
+def test_in_check_strings() -> None:
+    """
+    Test ``In``.
+    """
+    operations = {(Operator.IN, tuple({'b', 'a'}))}
+    filter_ = In.build(operations)
+    assert isinstance(filter_, In)
+    assert filter_.check('a')
+    assert filter_.check('b')
+    assert not filter_.check('c')
+    assert str(filter_) == "IN('a', 'b')"
+
+def test_in_multiple_value_impossible() -> None:
+    """
+    Test multiple IN operations are not allowed.
+    """
+    operations = {
+        (Operator.IN, tuple({0, 1})),
+        (Operator.IN, tuple({2, 3})),
+    }
+    filter_ = In.build(operations)
+    assert isinstance(filter_, Impossible)

--- a/tests/filters_test.py
+++ b/tests/filters_test.py
@@ -387,6 +387,7 @@ def test_is_not_null() -> None:
     assert IsNotNull().check(None) is False
     assert IsNotNull() != 0
 
+
 def test_in_numbers() -> None:
     """
     Test ``In``.
@@ -396,20 +397,22 @@ def test_in_numbers() -> None:
     assert isinstance(filter_, In)
     assert str(filter_) == "IN(0, 1, 5)"
 
+
 def test_in_check_strings() -> None:
     """
     Test ``In``.
     """
-    operations = {(Operator.IN, tuple({'b', 'a'}))}
+    operations = {(Operator.IN, tuple({"b", "a"}))}
     filter_ = In.build(operations)
     assert isinstance(filter_, In)
-    assert filter_.check('a')
-    assert filter_.check('b')
-    assert not filter_.check('c')
+    assert filter_.check("a")
+    assert filter_.check("b")
+    assert not filter_.check("c")
     assert str(filter_) in [
         "IN('b', 'a')",
         "IN('a', 'b')",
     ]
+
 
 def test_in_multiple_value_impossible() -> None:
     """


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
Up to now, the constraintargs for a WHERE IN clause with more than one element in a list comes in as None in the VTCursor.Filter() method. With the use of the VTTable.BestIndexObject() and using apsw 3.41.0+, it is possible to get this list passed in as a set to the VTCursor.Filter() method. This PR serializes that set to a string. 

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
- You will probably need to change the setup.cfg to set apsw>=3.41.0
- set supports_requested_columns = True and supports_in_statements = True in your adapter's class derived from the Adapter base class..
- make sure to properly handle the deserialization of a stringified set. A WHERE x IN (item) clause gets serialized to the string ==item, while the same clause with one more item WHERE x IN (item1, item2) gets serialized to the string IN("item1", "item2").
