### PR TITLE
feat(generic JSON): pass request headers as query parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Allow passing request headers to the generic JSON adapter via query arguments (#354)
+
 Version 1.2.1 - 2023-04-14
 ==========================
 

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -451,3 +451,11 @@ Or via SQLAlchemy:
             },
         },
     )
+
+Or via query parameters:
+
+.. code-block:: sql
+
+   SELECT * FROM "https://api.example.com/?_s_headers=(X-Auth-Token:SECRET)"
+
+Note that if passing the headers via query parameters the dictionary should be serialized using `RISON <https://pypi.org/project/prison/>`_.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -108,6 +108,8 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.20.0
     # via shillelagh
+prison==0.2.1
+    # via shillelagh
 prompt-toolkit==3.0.30
     # via shillelagh
 psutil==5.9.1
@@ -167,6 +169,7 @@ six==1.16.0
     # via
     #   google-auth
     #   html5lib
+    #   prison
     #   python-dateutil
     #   requests-mock
     #   url-normalize

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ testing =
     pandas>=1.2.2
     pip-tools>=6.4.0
     pre-commit>=2.13.0
+    prison>=0.2.1
     prompt_toolkit>=3
     psutil>=5.8.0
     pyfakefs>=4.3.3
@@ -133,6 +134,7 @@ datasetteapi =
     requests-cache==0.7.1
 genericjsonapi =
     jsonpath-python>=1.0.5
+    prison>=0.2.1
     requests-cache==0.7.1
 githubapi =
     jsonpath-python>=1.0.5


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Allow passing request headers in the generic JSON adapter as query parameters, see https://github.com/betodealmeida/shillelagh/pull/337#issuecomment-1512007720.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
