### PR TITLE
chore(pytest): add "src" to PYTHONPATH

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -202,6 +202,7 @@ norecursedirs =
     build
     .tox
 testpaths = tests
+pythonpath = src
 
 [coverage:report]
 fail_under = 100


### PR DESCRIPTION
In order to quickly run pytest without running `pip install .` first,
the PYTHONPATH needs to be extended.

See pytest docs for more information. [1]

Without `src` on the PYTHONPATH, `pytest` fails with
`ModuleNotFoundError: No module named 'shillelagh'`

[1] https://docs.pytest.org/en/7.3.x/explanation/goodpractices.html#tests-outside-application-code
