### PR TITLE
chore: only warn if adapter was specified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Only warn of errors when loading adapters if they are explicitly requested (#360)
+
 Version 1.2.2 - 2023-04-17
 ==========================
 

--- a/src/shillelagh/adapters/registry.py
+++ b/src/shillelagh/adapters/registry.py
@@ -32,7 +32,7 @@ class AdapterLoader:
         for entry_point in iter_entry_points("shillelagh.adapter"):
             self.loaders[entry_point.name].append(entry_point.load)
 
-    def load(self, name: str, safe: bool = False) -> Type[Adapter]:
+    def load(self, name: str, safe: bool = False, warn: bool = False) -> Type[Adapter]:
         """
         Load a given entry point by its name.
         """
@@ -43,7 +43,8 @@ class AdapterLoader:
             try:
                 return cast(Type[Adapter], load())
             except (ImportError, ModuleNotFoundError) as ex:
-                _logger.warning("Couldn't load adapter %s", name)
+                if warn:
+                    _logger.warning("Couldn't load adapter %s", name)
                 _logger.debug(ex)
                 continue
 
@@ -76,7 +77,7 @@ class AdapterLoader:
             return {}
 
         loaded_adapters = {
-            name: self.load(name, safe=True)
+            name: self.load(name, safe=True, warn=True)
             for name in self.loaders
             if name in adapters
         }

--- a/tests/adapters/registry_test.py
+++ b/tests/adapters/registry_test.py
@@ -3,6 +3,7 @@ Tests for the adapter registry.
 """
 
 import pytest
+from pytest_mock import MockerFixture
 
 from shillelagh.adapters.file.csvfile import CSVFile
 from shillelagh.adapters.registry import AdapterLoader
@@ -76,3 +77,23 @@ def test_load_only_requested_adapters(registry: AdapterLoader) -> None:
         registry.load_all(["valid", "invalid"])
     assert str(excinfo.value) == "Unable to load adapter invalid"
     assert registry.load_all() == {"valid": FakeAdapter}
+
+
+def test_load_warning(mocker: MockerFixture, registry: AdapterLoader) -> None:
+    """
+    Test that warnings are only logged in safe mode.
+    """
+    _logger = mocker.patch("shillelagh.adapters.registry._logger")
+
+    def load_error() -> None:
+        raise ImportError("Error!")
+
+    registry.loaders["dummy"].append(load_error)
+
+    with pytest.raises(InterfaceError):
+        registry.load("dummy")
+    assert _logger.warning.not_called()
+
+    with pytest.raises(InterfaceError):
+        registry.load("dummy", warn=True)
+    assert _logger.warning.called_with("Couldn't load adapter %s", "dummy")


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
