### PR TITLE
refactor: pkg_resources -> importlib.metadata

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,8 @@ greenlet==2.0.2
     #   sqlalchemy
 idna==3.3
     # via requests
+importlib-metadata==6.7.0
+    # via shillelagh
 packaging==23.0
     # via shillelagh
 python-dateutil==2.8.2
@@ -33,3 +35,5 @@ typing-extensions==4.3.0
     # via shillelagh
 urllib3==1.26.10
     # via requests
+zipp==3.15.0
+    # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,6 +72,8 @@ idna==3.3
     # via
     #   requests
     #   yarl
+importlib-metadata==6.7.0
+    # via shillelagh
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
@@ -217,6 +219,8 @@ wrapt==1.14.1
     # via astroid
 yarl==1.8.1
     # via shillelagh
+zipp==3.15.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ setup_requires = pyscaffold>=3.2a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 install_requires =
-    importlib-metadata; python_version<"3.8"
+    importlib-metadata; python_version<"3.10"
     apsw>=3.9.2
     python_dateutil>=2.8.1
     requests>=2.31.0

--- a/src/shillelagh/adapters/registry.py
+++ b/src/shillelagh/adapters/registry.py
@@ -8,7 +8,7 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Optional, Type, cast
 
-from pkg_resources import iter_entry_points
+from importlib_metadata import entry_points
 
 from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import InterfaceError
@@ -29,7 +29,7 @@ class AdapterLoader:
 
     def __init__(self):
         self.loaders = defaultdict(list)
-        for entry_point in iter_entry_points("shillelagh.adapter"):
+        for entry_point in entry_points(group="shillelagh.adapter"):
             self.loaders[entry_point.name].append(entry_point.load)
 
     def load(self, name: str, safe: bool = False, warn: bool = False) -> Type[Adapter]:

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -5,7 +5,7 @@ import json
 import time
 from typing import Any, Dict, List, Type
 
-import pkg_resources
+from importlib_metadata import distribution
 
 from shillelagh.adapters.base import Adapter
 from shillelagh.lib import find_adapter
@@ -71,4 +71,4 @@ def version() -> str:
         0.7.4
 
     """
-    return pkg_resources.get_distribution("shillelagh").version
+    return str(distribution("shillelagh").version)

--- a/tests/functions_test.py
+++ b/tests/functions_test.py
@@ -4,8 +4,8 @@ Tests for shillelagh.functions.
 import json
 
 import apsw
-import pkg_resources
 import pytest
+from importlib_metadata import distribution
 from pytest_mock import MockerFixture
 
 from shillelagh.adapters.registry import AdapterLoader
@@ -73,7 +73,7 @@ def test_version_from_sql() -> None:
     connection = connect(":memory:")
     cursor = connection.cursor()
     cursor.execute("SELECT version()")
-    shillelagh_version = pkg_resources.get_distribution("shillelagh").version
+    shillelagh_version = distribution("shillelagh").version
     apsw_version = apsw.apswversion()  # pylint: disable=c-extension-no-member
     version = f"{shillelagh_version} (apsw {apsw_version})"
     assert cursor.fetchall() == [(version,)]


### PR DESCRIPTION
pkg_resources is in the process of being deprecated in favor of
importlib.metadata and importlib.resources

importlib.metadata has been available in the standard library since 3.8

And as of 3.10 the importlib.metadata API is no longer provisional

In order to support Python version older than 3.10, the
`importlib_metadata` backport is used instead of the actual
`importlib.metadata` API.

(NOTE: There was no explicit install_require entry that needed removing
in setup.py for the setuptools package which provides the pkg_resources
module. It seems that it was merely assumed that setuptools is always
present, which is actually not the case.)
