### PR TITLE
feat(gsheets): implement durations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 Next
 ====
 
+Version 1.2.6 - 2023-07-20
+==========================
+
+- Add support for querying durations in Google Sheets ()
+
 Version 1.2.5 - 2023-07-14
 ==========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Next
 Version 1.2.6 - 2023-07-20
 ==========================
 
-- Add support for querying durations in Google Sheets ()
+- Add support for querying durations in Google Sheets (#374)
 
 Version 1.2.5 - 2023-07-14
 ==========================

--- a/src/shillelagh/adapters/api/gsheets/adapter.py
+++ b/src/shillelagh/adapters/api/gsheets/adapter.py
@@ -47,7 +47,6 @@ AVERAGE_NUMBER_OF_ROWS = 1000
 
 
 class GSheetsAPI(Adapter):  # pylint: disable=too-many-instance-attributes
-
     r"""
     A Google Sheets adapter.
 

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -2,7 +2,7 @@
 Custom fields for the GSheets adapter.
 """
 import datetime
-from typing import Any, List, Optional, Type
+from typing import Any, List, Optional, Type, Union
 
 from shillelagh.adapters.api.gsheets.parsing.date import (
     format_date_time_pattern,
@@ -306,7 +306,7 @@ class GSheetsNumber(GSheetsField[str, float]):
 
         return format_number_pattern(value, self.pattern)
 
-    def quote(self, value: Optional[str]) -> str:
+    def quote(self, value: Optional[Union[str, int, float]]) -> str:
         if value == "" or value is None:
             return "null"
 

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -20,6 +20,10 @@ DATETIME_SQL_QUOTE = "%Y-%m-%d %H:%M:%S"
 DATE_SQL_QUOTE = "%Y-%m-%d"
 TIME_SQL_QUOTE = "%H:%M:%S"
 
+# When filtering a sheet based on a duration we need to convert it into a datetime
+# starting at 1899-12-30, for some reason. That is not documented anywhere, obviously.
+DURATION_OFFSET = datetime.datetime(1899, 12, 30)
+
 
 class GSheetsField(Field[Internal, External]):
     """
@@ -232,15 +236,12 @@ class GSheetsDuration(GSheetsField[str, datetime.timedelta]):
         if self.pattern is None or value == "" or value is None:
             return "null"
 
-        # On SQL queries the timestamp should be prefix by "duration"
-        value = self.format(
-            parse_date_time_pattern(
-                value,
-                self.pattern,
-                datetime.timedelta,
-            ),
+        timestamp = DURATION_OFFSET + parse_date_time_pattern(
+            value,
+            self.pattern,
+            datetime.timedelta,
         )
-        return f"duration '{value}'"
+        return f"datetime '{timestamp}'"
 
 
 class GSheetsBoolean(GSheetsField[str, bool]):

--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -206,6 +206,43 @@ class GSheetsTime(GSheetsField[str, datetime.time]):
         return f"timeofday '{value}'"
 
 
+class GSheetsDuration(GSheetsField[str, datetime.timedelta]):
+    """
+    A GSheets duration.
+    """
+
+    type = "DURATION"
+    db_api_type = "DATETIME"
+
+    def parse(self, value: Optional[str]) -> Optional[datetime.timedelta]:
+        if self.pattern is None or value is None or value == "":
+            return None
+
+        return parse_date_time_pattern(value, self.pattern, datetime.timedelta)
+
+    def format(self, value: Optional[datetime.timedelta]) -> str:
+        # This method is used only when inserting or updating rows, so we
+        # encode NULLs as an empty string to match the Google Sheets API.
+        if self.pattern is None or value is None:
+            return ""
+
+        return format_date_time_pattern(value, self.pattern)
+
+    def quote(self, value: Optional[str]) -> str:
+        if self.pattern is None or value == "" or value is None:
+            return "null"
+
+        # On SQL queries the timestamp should be prefix by "duration"
+        value = self.format(
+            parse_date_time_pattern(
+                value,
+                self.pattern,
+                datetime.timedelta,
+            ),
+        )
+        return f"duration '{value}'"
+
+
 class GSheetsBoolean(GSheetsField[str, bool]):
     """
     A GSheets boolean.

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -14,11 +14,13 @@ from shillelagh.adapters.api.gsheets.fields import (
     GSheetsBoolean,
     GSheetsDate,
     GSheetsDateTime,
+    GSheetsDuration,
     GSheetsField,
     GSheetsNumber,
     GSheetsString,
     GSheetsTime,
 )
+from shillelagh.adapters.api.gsheets.parsing.date import infer_column_type
 from shillelagh.adapters.api.gsheets.types import SyncMode
 from shillelagh.adapters.api.gsheets.typing import (
     QueryResultsCell,
@@ -46,10 +48,10 @@ def get_field(
     """
     Return a Shillelagh ``Field`` from a Google Chart API results column.
     """
-    # Fix for GSheets return an incorrect type. We should be able to detect the type based
-    # on the pattern, instead of relying on the return type.
-    if col["type"] == "datetime" and col.get("pattern") == "h:mm:ss am/pm":
-        col["type"] = "timeofday"
+    # GSheets returns type ``datetime`` for timestamps, but also for time of day and
+    # durations. We need to tokenize the pattern in order to figure out the correct type.
+    if col["type"] == "datetime":
+        col["type"] = infer_column_type(col["pattern"])
 
     type_map: Dict[str, Tuple[Type[GSheetsField], List[Type[Filter]]]] = {
         "string": (GSheetsString, [Range, Equal, NotEqual, Like, IsNull, IsNotNull]),
@@ -58,6 +60,7 @@ def get_field(
         "date": (GSheetsDate, [Range, Equal, NotEqual, IsNull, IsNotNull]),
         "datetime": (GSheetsDateTime, [Range, Equal, NotEqual, IsNull, IsNotNull]),
         "timeofday": (GSheetsTime, [Range, Equal, NotEqual, IsNull, IsNotNull]),
+        "duration": (GSheetsDuration, [Range, Equal, NotEqual, IsNull, IsNotNull]),
     }
     class_, filters = type_map.get(
         col["type"],

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -50,7 +50,7 @@ def get_field(
     """
     # GSheets returns type ``datetime`` for timestamps, but also for time of day and
     # durations. We need to tokenize the pattern in order to figure out the correct type.
-    if col["type"] == "datetime":
+    if col["type"] == "datetime" and "pattern" in col:
         col["type"] = infer_column_type(col["pattern"])
 
     type_map: Dict[str, Tuple[Type[GSheetsField], List[Type[Filter]]]] = {

--- a/src/shillelagh/adapters/api/gsheets/parsing/base.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/base.py
@@ -19,14 +19,22 @@ class Token(Generic[Valid]):
         self.token = token
 
     @classmethod
-    def match(cls, pattern: str) -> bool:
+    def match(
+        cls,
+        pattern: str,
+        history: List["Token"],  # pylint: disable=unused-argument
+    ) -> bool:
         """
         Check if token handles the beginning of the pattern.
         """
         return bool(re.match(cls.regex, pattern))
 
     @classmethod
-    def consume(cls, pattern: str) -> Tuple["Token", str]:
+    def consume(
+        cls,
+        pattern: str,
+        history: List["Token"],  # pylint: disable=unused-argument
+    ) -> Tuple["Token", str]:
         """
         Consume the pattern, returning the token and the remaining pattern.
         """
@@ -99,11 +107,11 @@ def tokenize(pattern: str, classes: List[Type[Token]]) -> Iterator[Token]:
     """
     Tokenize a pattern.
     """
-    tokens = []
+    tokens: List[Token] = []
     while pattern:
         for class_ in classes:  # pragma: no cover
-            if class_.match(pattern):
-                token, pattern = class_.consume(pattern)
+            if class_.match(pattern, tokens):
+                token, pattern = class_.consume(pattern, tokens)
                 tokens.append(token)
                 break
 

--- a/src/shillelagh/adapters/file/csvfile.py
+++ b/src/shillelagh/adapters/file/csvfile.py
@@ -63,7 +63,6 @@ class RowTracker:
 
 
 class CSVFile(Adapter):
-
     r"""
     An adapter for CSV files.
 
@@ -277,7 +276,10 @@ class CSVFile(Adapter):
         This method will get rid of deleted rows in the files.
         """
         if not self.local:
-            self.path.unlink()
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
             return
 
         if not self.modified:

--- a/tests/adapters/api/gsheets/adapter_test.py
+++ b/tests/adapters/api/gsheets/adapter_test.py
@@ -1917,9 +1917,10 @@ def test_unidirectional_sync_mode(
     """
     Test UNIDIRECTIONAL mode.
     """
+    credentials = mocker.MagicMock()
     mocker.patch(
         "shillelagh.adapters.api.gsheets.adapter.get_credentials",
-        return_value="SECRET",
+        return_value=credentials,
     )
 
     session = requests.Session()

--- a/tests/adapters/api/gsheets/fields_test.py
+++ b/tests/adapters/api/gsheets/fields_test.py
@@ -10,6 +10,7 @@ from shillelagh.adapters.api.gsheets.fields import (
     GSheetsBoolean,
     GSheetsDate,
     GSheetsDateTime,
+    GSheetsDuration,
     GSheetsNumber,
     GSheetsString,
     GSheetsTime,
@@ -17,7 +18,7 @@ from shillelagh.adapters.api.gsheets.fields import (
 from shillelagh.fields import ISODateTime, Order
 
 
-def test_comparison():
+def test_comparison() -> None:
     """
     Test that a GSheets field is different from a standard field.
     """
@@ -29,7 +30,7 @@ def test_comparison():
     )
 
 
-def test_GSheetsDateTime():
+def test_GSheetsDateTime() -> None:
     """
     Test ``GSheetsDateTime``.
     """
@@ -63,7 +64,7 @@ def test_GSheetsDateTime():
     )
 
 
-def test_GSheetsDateTime_timezone():
+def test_GSheetsDateTime_timezone() -> None:
     """
     Test GSheetsDateTime when timezone is set.
     """
@@ -81,7 +82,7 @@ def test_GSheetsDateTime_timezone():
     )
 
 
-def test_GSheetsDate():
+def test_GSheetsDate() -> None:
     """
     Test ``GSheetsDate``.
     """
@@ -105,7 +106,7 @@ def test_GSheetsDate():
     assert GSheetsDate(pattern="M/d/yyyy").quote("12/31/2020") == "date '2020-12-31'"
 
 
-def test_GSheetsTime():
+def test_GSheetsTime() -> None:
     """
     Test ``GSheetsTime``.
     """
@@ -132,7 +133,36 @@ def test_GSheetsTime():
     )
 
 
-def test_GSheetsBoolean():
+def test_GSheetsDuration() -> None:
+    """
+    Test ``GSheetsDuration``.
+    """
+    assert GSheetsDuration().parse(None) is None
+    assert GSheetsDuration().parse("") is None
+
+    assert GSheetsDuration(pattern="[h]:mm:ss").parse("12:34:56") == datetime.timedelta(
+        hours=12,
+        minutes=34,
+        seconds=56,
+    )
+
+    assert GSheetsDuration().format(None) == ""
+    assert (
+        GSheetsDuration(pattern="[h]:mm:ss").format(
+            datetime.timedelta(hours=12, minutes=34, seconds=56),
+        )
+        == "12:34:56"
+    )
+
+    assert GSheetsDuration().quote(None) == "null"
+    assert GSheetsDuration().quote("") == "null"
+    assert (
+        GSheetsDuration(pattern="[h]:mm:ss").quote("12:34:56")
+        == "datetime '1899-12-30 12:34:56'"
+    )
+
+
+def test_GSheetsBoolean() -> None:
     """
     Test ``GSheetsBoolean``.
     """
@@ -151,7 +181,7 @@ def test_GSheetsBoolean():
     assert GSheetsBoolean().quote("FALSE") == "false"
 
 
-def test_GSheetsNumber():
+def test_GSheetsNumber() -> None:
     """
     Test ``GSheetsNumber``.
     """
@@ -175,7 +205,7 @@ def test_GSheetsNumber():
     assert GSheetsNumber().quote(1.0) == "1.0"
 
 
-def test_GSheetsString():
+def test_GSheetsString() -> None:
     """
     Test ``GSheetsString``.
     """

--- a/tests/adapters/api/gsheets/lib_test.py
+++ b/tests/adapters/api/gsheets/lib_test.py
@@ -32,7 +32,7 @@ from shillelagh.fields import Order
 from shillelagh.filters import Equal, IsNotNull, IsNull, Like, NotEqual, Range
 
 
-def test_get_field():
+def test_get_field() -> None:
     """
     Test ``get_field``.
     """
@@ -93,7 +93,7 @@ def test_get_field():
     )
 
 
-def test_format_error_message():
+def test_format_error_message() -> None:
     """
     Test ``format_error_message``.
     """
@@ -113,7 +113,7 @@ def test_format_error_message():
     assert format_error_message(response["errors"]) == "Invalid query: NO_COLUMN: C"
 
 
-def test_get_url():
+def test_get_url() -> None:
     """
     Test ``get_url``.
     """
@@ -146,7 +146,7 @@ def test_get_url():
     )
 
 
-def test_get_sync_mode():
+def test_get_sync_mode() -> None:
     """
     Test ``get_sync_mode``.
     """
@@ -181,7 +181,7 @@ def test_get_sync_mode():
     assert str(excinfo.value) == "Invalid sync mode: INVALID"
 
 
-def test_gen_letters():
+def test_gen_letters() -> None:
     """
     Test ``gen_letters``.
     """
@@ -250,7 +250,7 @@ def test_gen_letters():
     ]
 
 
-def test_get_index_from_letters():
+def test_get_index_from_letters() -> None:
     """
     Test ``get_index_from_letters``.
     """
@@ -261,7 +261,7 @@ def test_get_index_from_letters():
     assert get_index_from_letters("AAA") == 702
 
 
-def test_get_values_from_row():
+def test_get_values_from_row() -> None:
     """
     Test ``get_values_from_row``.
     """
@@ -334,7 +334,7 @@ def test_get_credentials(mocker: MockerFixture):
     app_default_credentials.assert_called()
 
 
-def test_get_value_from_cell():
+def test_get_value_from_cell() -> None:
     """
     Test ``get_value_from_cell``.
     """

--- a/tests/adapters/api/gsheets/lib_test.py
+++ b/tests/adapters/api/gsheets/lib_test.py
@@ -2,6 +2,7 @@
 Tests for shillelagh.adapters.api.gsheets.lib.
 """
 import itertools
+from typing import List, cast
 
 import dateutil.tz
 import pytest
@@ -27,6 +28,7 @@ from shillelagh.adapters.api.gsheets.lib import (
     get_values_from_row,
 )
 from shillelagh.adapters.api.gsheets.types import SyncMode
+from shillelagh.adapters.api.gsheets.typing import QueryResultsError
 from shillelagh.exceptions import ProgrammingError
 from shillelagh.fields import Order
 from shillelagh.filters import Equal, IsNotNull, IsNull, Like, NotEqual, Range
@@ -110,7 +112,10 @@ def test_format_error_message() -> None:
             },
         ],
     }
-    assert format_error_message(response["errors"]) == "Invalid query: NO_COLUMN: C"
+    assert (
+        format_error_message(cast(List[QueryResultsError], response["errors"]))
+        == "Invalid query: NO_COLUMN: C"
+    )
 
 
 def test_get_url() -> None:

--- a/tests/adapters/api/gsheets/parsing/base_test.py
+++ b/tests/adapters/api/gsheets/parsing/base_test.py
@@ -15,7 +15,7 @@ from shillelagh.adapters.api.gsheets.parsing.base import (
 from shillelagh.adapters.api.gsheets.parsing.date import DD, MM, YYYY
 
 
-def test_literal_token():
+def test_literal_token() -> None:
     """
     Test the literal token.
     """
@@ -61,7 +61,7 @@ def test_literal_token():
     assert str(excinfo.value) == "B"
 
 
-def test_tokenize():
+def test_tokenize() -> None:
     """
     Test the tokenize function.
     """
@@ -84,7 +84,7 @@ def test_tokenize():
     ]
 
 
-def test_is_unescaped_literal():
+def test_is_unescaped_literal() -> None:
     """
     Test the is_unescaped_literal function.
     """

--- a/tests/adapters/api/gsheets/parsing/base_test.py
+++ b/tests/adapters/api/gsheets/parsing/base_test.py
@@ -26,10 +26,10 @@ def test_literal_token():
         LITERAL,
     ]
 
-    assert LITERAL.match(r"\d")
-    assert LITERAL.match('"dd/mm/yy"')
+    assert LITERAL.match(r"\d", [])
+    assert LITERAL.match('"dd/mm/yy"', [])
     # matches eveything
-    assert LITERAL.match("d")
+    assert LITERAL.match("d", [])
 
     token = LITERAL("@")
     tokens = list(tokenize("@", classes))

--- a/tests/adapters/api/gsheets/parsing/date_test.py
+++ b/tests/adapters/api/gsheets/parsing/date_test.py
@@ -127,13 +127,13 @@ def test_h_token():
     """
     token = H("h")
 
-    assert H.match("h:mm:ss")
-    assert not H.match("hh:mm:ss")
-    assert not H.match("s")
+    assert H.match("h:mm:ss", [])
+    assert not H.match("hh:mm:ss", [])
+    assert not H.match("s", [])
 
-    assert H.consume("h:mm:ss") == (token, ":mm:ss")
+    assert H.consume("h:mm:ss", []) == (token, ":mm:ss")
     with pytest.raises(Exception) as excinfo:
-        H.consume("hh:mm:ss")
+        H.consume("hh:mm:ss", [])
     assert str(excinfo.value) == "Token could not find match"
 
     tokens = list(tokenize("h:mm:ss", classes))
@@ -158,9 +158,9 @@ def test_hhplus_token():
     """
     token = HHPlus("hhh")
 
-    assert HHPlus.match("hhh:mm:ss")
-    assert HHPlus.match("hhhh:mm:ss")
-    assert not HHPlus.match("h:mm:ss")
+    assert HHPlus.match("hhh:mm:ss", [])
+    assert HHPlus.match("hhhh:mm:ss", [])
+    assert not HHPlus.match("h:mm:ss", [])
 
     tokens = list(tokenize("hhh:mm:ss", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "13"
@@ -179,11 +179,11 @@ def test_m_token():
     """
     token = M("m")
 
-    assert M.match("m/d/y")
-    assert not M.match("mm/dd/yyyy")
-    assert not M.match("M/d/y")
+    assert M.match("m/d/y", [])
+    assert not M.match("mm/dd/yyyy", [])
+    assert not M.match("M/d/y", [])
 
-    assert M.consume("m/d/y") == (token, "/d/y")
+    assert M.consume("m/d/y", []) == (token, "/d/y")
 
     tokens = list(tokenize("m/d/y", classes))
     token = tokens[0]
@@ -228,10 +228,10 @@ def test_mm_token():
     """
     token = MM("mm")
 
-    assert MM.match("mm/dd/yyy")
-    assert not MM.match("mmm/dd/yyy")
+    assert MM.match("mm/dd/yyy", [])
+    assert not MM.match("mmm/dd/yyy", [])
 
-    assert MM.consume("mm/dd/yyyy") == (token, "/dd/yyyy")
+    assert MM.consume("mm/dd/yyyy", []) == (token, "/dd/yyyy")
 
     tokens = list(tokenize("mm/dd/yyy", classes))
     token = tokens[0]
@@ -245,10 +245,10 @@ def test_mmm_token():
     """
     token = MMM("mmm")
 
-    assert MMM.match("mmm/dd/yyy")
-    assert not MMM.match("mm/dd/yyy")
+    assert MMM.match("mmm/dd/yyy", [])
+    assert not MMM.match("mm/dd/yyy", [])
 
-    assert MMM.consume("mmm/dd/yyyy") == (token, "/dd/yyyy")
+    assert MMM.consume("mmm/dd/yyyy", []) == (token, "/dd/yyyy")
 
     tokens = list(tokenize("mmm/dd/yyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "Nov"
@@ -261,10 +261,10 @@ def test_mmmm_token():
     """
     token = MMMM("mmmm")
 
-    assert MMMM.match("mmmm/dd/yyy")
-    assert not MMMM.match("mmm/dd/yyy")
+    assert MMMM.match("mmmm/dd/yyy", [])
+    assert not MMMM.match("mmm/dd/yyy", [])
 
-    assert MMMM.consume("mmmm/dd/yyyy") == (token, "/dd/yyyy")
+    assert MMMM.consume("mmmm/dd/yyyy", []) == (token, "/dd/yyyy")
 
     tokens = list(tokenize("mmmm/dd/yyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "November"
@@ -277,10 +277,10 @@ def test_mmmmm_token():
     """
     token = MMMMM("mmmmm")
 
-    assert MMMMM.match("mmmmm/dd/yyy")
-    assert not MMMMM.match("mmm/dd/yyy")
+    assert MMMMM.match("mmmmm/dd/yyy", [])
+    assert not MMMMM.match("mmm/dd/yyy", [])
 
-    assert MMMMM.consume("mmmmm/dd/yyyy") == (token, "/dd/yyyy")
+    assert MMMMM.consume("mmmmm/dd/yyyy", []) == (token, "/dd/yyyy")
 
     tokens = list(tokenize("mmmmm/dd/yyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "N"
@@ -299,10 +299,10 @@ def test_s_token():
     """
     token = S("s")
 
-    assert S.match("s.00")
-    assert not S.match("ss.00")
+    assert S.match("s.00", [])
+    assert not S.match("ss.00", [])
 
-    assert S.consume("s.00") == (token, ".00")
+    assert S.consume("s.00", []) == (token, ".00")
 
     tokens = list(tokenize("h:m:s", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 5, 16), tokens) == "5"
@@ -323,10 +323,10 @@ def test_ss_token():
     """
     token = SS("ss")
 
-    assert SS.match("ss.00")
-    assert not SS.match("s.00")
+    assert SS.match("ss.00", [])
+    assert not SS.match("s.00", [])
 
-    assert SS.consume("ss.00") == (token, ".00")
+    assert SS.consume("ss.00", []) == (token, ".00")
 
     tokens = list(tokenize("hh:mm:ss", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "15"
@@ -340,11 +340,11 @@ def test_hplusduration_token():
     """
     token = HPlusDuration("[hh]")
 
-    assert HPlusDuration.match("[h]")
-    assert HPlusDuration.match("[hh]")
-    assert not HPlusDuration.match("hh")
+    assert HPlusDuration.match("[h]", [])
+    assert HPlusDuration.match("[hh]", [])
+    assert not HPlusDuration.match("hh", [])
 
-    assert HPlusDuration.consume("[hh]:[mm]:[ss].000") == (token, ":[mm]:[ss].000")
+    assert HPlusDuration.consume("[hh]:[mm]:[ss].000", []) == (token, ":[mm]:[ss].000")
 
     tokens = list(tokenize("[hh]:[mm]:[ss].000", classes))
     assert (
@@ -366,6 +366,11 @@ def test_hplusduration_token():
         ":03:04.500",
     )
 
+    # should never happen
+    with pytest.raises(Exception) as excinfo:
+        token.parse("invalid", [])
+    assert str(excinfo.value) == "Cannot parse value: invalid"
+
 
 def test_mplusduration_token():
     """
@@ -373,11 +378,11 @@ def test_mplusduration_token():
     """
     token = MPlusDuration("[mm]")
 
-    assert MPlusDuration.match("[m]")
-    assert MPlusDuration.match("[mm]")
-    assert not MPlusDuration.match("mm")
+    assert MPlusDuration.match("[m]", [])
+    assert MPlusDuration.match("[mm]", [])
+    assert not MPlusDuration.match("mm", [])
 
-    assert MPlusDuration.consume("[mm]:[ss].000") == (token, ":[ss].000")
+    assert MPlusDuration.consume("[mm]:[ss].000", []) == (token, ":[ss].000")
 
     tokens = list(tokenize("[hh]:[mm]:[ss].000", classes))
     assert (
@@ -405,6 +410,11 @@ def test_mplusduration_token():
         ":04.500",
     )
 
+    # should never happen
+    with pytest.raises(Exception) as excinfo:
+        token.parse("invalid", [])
+    assert str(excinfo.value) == "Cannot parse value: invalid"
+
 
 def test_splusduration_token():
     """
@@ -412,11 +422,16 @@ def test_splusduration_token():
     """
     token = SPlusDuration("[ss]")
 
-    assert SPlusDuration.match("[s]")
-    assert SPlusDuration.match("[ss]")
-    assert not SPlusDuration.match("ss")
+    assert SPlusDuration.match("[s]", [])
+    assert SPlusDuration.match("[ss]", [])
+    assert not SPlusDuration.match("ss", [])
 
-    assert SPlusDuration.consume("[ss].000") == (token, ".000")
+    assert SPlusDuration.consume("[ss].000", []) == (token, ".000")
+
+    # should never happen
+    with pytest.raises(Exception) as excinfo:
+        SPlusDuration.consume("invalid", [])
+    assert str(excinfo.value) == "Token could not find match"
 
     tokens = list(tokenize("[hh]:[mm]:[ss].000", classes))
     assert (
@@ -442,6 +457,11 @@ def test_splusduration_token():
         ".500",
     )
 
+    # should never happen
+    with pytest.raises(Exception) as excinfo:
+        token.parse("invalid", [])
+    assert str(excinfo.value) == "Cannot parse value: invalid"
+
 
 def test_d_token():
     """
@@ -449,10 +469,10 @@ def test_d_token():
     """
     token = D("d")
 
-    assert D.match("d")
-    assert not D.match("dd")
+    assert D.match("d", [])
+    assert not D.match("dd", [])
 
-    assert D.consume("d/m/y") == (token, "/m/y")
+    assert D.consume("d/m/y", []) == (token, "/m/y")
 
     tokens = list(tokenize("d/m/y", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "12"
@@ -469,11 +489,11 @@ def test_dd_token():
     """
     token = DD("dd")
 
-    assert DD.match("dd")
-    assert not DD.match("d")
-    assert not DD.match("ddd")
+    assert DD.match("dd", [])
+    assert not DD.match("d", [])
+    assert not DD.match("ddd", [])
 
-    assert DD.consume("dd/mm/yyyy") == (token, "/mm/yyyy")
+    assert DD.consume("dd/mm/yyyy", []) == (token, "/mm/yyyy")
 
     tokens = list(tokenize("dd/mm/yyyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "12"
@@ -487,11 +507,11 @@ def test_ddd_token():
     """
     token = DDD("ddd")
 
-    assert DDD.match("ddd")
-    assert not DDD.match("dd")
-    assert not DDD.match("dddd")
+    assert DDD.match("ddd", [])
+    assert not DDD.match("dd", [])
+    assert not DDD.match("dddd", [])
 
-    assert DDD.consume("ddd, dd/mm/yyyy") == (token, ", dd/mm/yyyy")
+    assert DDD.consume("ddd, dd/mm/yyyy", []) == (token, ", dd/mm/yyyy")
 
     tokens = list(tokenize("ddd, dd/mm/yyyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "Fri"
@@ -504,11 +524,11 @@ def test_ddddplus_token():
     """
     token = DDDDPlus("dddd")
 
-    assert DDDDPlus.match("dddd")
-    assert DDDDPlus.match("ddddd")
-    assert not DDDDPlus.match("ddd")
+    assert DDDDPlus.match("dddd", [])
+    assert DDDDPlus.match("ddddd", [])
+    assert not DDDDPlus.match("ddd", [])
 
-    assert DDDDPlus.consume("dddd, dd/mm/yyyy") == (token, ", dd/mm/yyyy")
+    assert DDDDPlus.consume("dddd, dd/mm/yyyy", []) == (token, ", dd/mm/yyyy")
 
     tokens = list(tokenize("dddd, dd/mm/yyyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "Friday"
@@ -521,11 +541,11 @@ def test_yy_token():
     """
     token = YY("yy")
 
-    assert YY.match("y")
-    assert YY.match("yy")
-    assert not YY.match("yyy")
+    assert YY.match("y", [])
+    assert YY.match("yy", [])
+    assert not YY.match("yyy", [])
 
-    assert YY.consume("yy/mm/dd") == (token, "/mm/dd")
+    assert YY.consume("yy/mm/dd", []) == (token, "/mm/dd")
 
     tokens = list(tokenize("yy/mm/dd", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "21"
@@ -538,11 +558,11 @@ def test_yyyy_token():
     """
     token = YYYY("yyyy")
 
-    assert YYYY.match("yyy")
-    assert YYYY.match("yyyy")
-    assert not YYYY.match("yy")
+    assert YYYY.match("yyy", [])
+    assert YYYY.match("yyyy", [])
+    assert not YYYY.match("yy", [])
 
-    assert YYYY.consume("yyyy/mm/dd") == (token, "/mm/dd")
+    assert YYYY.consume("yyyy/mm/dd", []) == (token, "/mm/dd")
 
     tokens = list(tokenize("yyyy/mm/dd", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "2021"
@@ -555,12 +575,12 @@ def test_zero_token():
     """
     token = ZERO("00")
 
-    assert ZERO.match("0")
-    assert ZERO.match("00")
-    assert ZERO.match("000")
-    assert not ZERO.match("0000")
+    assert ZERO.match("0", [])
+    assert ZERO.match("00", [])
+    assert ZERO.match("000", [])
+    assert not ZERO.match("0000", [])
 
-    assert ZERO.consume("00") == (token, "")
+    assert ZERO.consume("00", []) == (token, "")
 
     tokens = list(tokenize("hh:mm:ss.000", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 167000), tokens) == "17"
@@ -577,11 +597,11 @@ def test_ap_token():
     """
     token = AP("a/p")
 
-    assert AP.match("a/p")
-    assert AP.match("A/P")
-    assert not AP.match("AM")
+    assert AP.match("a/p", [])
+    assert AP.match("A/P", [])
+    assert not AP.match("AM", [])
 
-    assert AP.consume("a/p hh:mm") == (token, " hh:mm")
+    assert AP.consume("a/p hh:mm", []) == (token, " hh:mm")
 
     tokens = list(tokenize("a/p hh:mm", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "p"
@@ -601,11 +621,11 @@ def test_ampm_token():
     """
     token = AMPM("am/pm")
 
-    assert AMPM.match("am/pm")
-    assert not AMPM.match("AM/PM")
-    assert not AMPM.match("AM")
+    assert AMPM.match("am/pm", [])
+    assert not AMPM.match("AM/PM", [])
+    assert not AMPM.match("AM", [])
 
-    assert AMPM.consume("am/pm hh:mm") == (token, " hh:mm")
+    assert AMPM.consume("am/pm hh:mm", []) == (token, " hh:mm")
 
     tokens = list(tokenize("am/pm hh:mm", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "PM"
@@ -619,6 +639,9 @@ def test_parse_date_time_pattern():
     """
     Test the parse_date_time_pattern function.
     """
+    parsed = parse_date_time_pattern("0:38:19", "[h]:mm:ss", timedelta)
+    assert parsed == timedelta(hours=0, minutes=38, seconds=19)
+
     parsed = parse_date_time_pattern(
         "2021/11/12 13:14:15.167",
         "yyyy/mm/dd hh:mm:ss.000",

--- a/tests/adapters/api/gsheets/parsing/date_test.py
+++ b/tests/adapters/api/gsheets/parsing/date_test.py
@@ -31,6 +31,7 @@ from shillelagh.adapters.api.gsheets.parsing.date import (
     S,
     SPlusDuration,
     format_date_time_pattern,
+    infer_column_type,
     parse_date_time_pattern,
     tokenize,
 )
@@ -61,7 +62,7 @@ classes = [
 ]
 
 
-def test_implementation():
+def test_implementation() -> None:
     """
     Test the examples from the reference.
 
@@ -113,7 +114,7 @@ def test_implementation():
     )
 
 
-def test_token():
+def test_token() -> None:
     """
     General tests for tokens.
     """
@@ -121,7 +122,7 @@ def test_token():
     assert H("h") != M("m")
 
 
-def test_h_token():
+def test_h_token() -> None:
     """
     Test the h token.
     """
@@ -152,7 +153,7 @@ def test_h_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_hhplus_token():
+def test_hhplus_token() -> None:
     """
     Test the hhh+ token.
     """
@@ -173,7 +174,7 @@ def test_hhplus_token():
     assert token.parse("303", tokens) == ({"hour": 30}, "3")
 
 
-def test_m_token():
+def test_m_token() -> None:
     """
     Test the m token.
     """
@@ -222,7 +223,7 @@ def test_m_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_mm_token():
+def test_mm_token() -> None:
     """
     Test the mm token.
     """
@@ -239,7 +240,7 @@ def test_mm_token():
     assert token.parse("123", tokens) == ({"month": 12}, "3")
 
 
-def test_mmm_token():
+def test_mmm_token() -> None:
     """
     Test the mmm token.
     """
@@ -255,7 +256,7 @@ def test_mmm_token():
     assert token.parse("Mar 1st", tokens) == ({"month": 3}, " 1st")
 
 
-def test_mmmm_token():
+def test_mmmm_token() -> None:
     """
     Test the mmm token.
     """
@@ -271,7 +272,7 @@ def test_mmmm_token():
     assert token.parse("March 1st", tokens) == ({"month": 3}, " 1st")
 
 
-def test_mmmmm_token():
+def test_mmmmm_token() -> None:
     """
     Test the mmmmm token.
     """
@@ -293,7 +294,7 @@ def test_mmmmm_token():
     assert str(excinfo.value) == "Unable to parse month letter unambiguously: M"
 
 
-def test_s_token():
+def test_s_token() -> None:
     """
     Test the s token.
     """
@@ -317,7 +318,7 @@ def test_s_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_ss_token():
+def test_ss_token() -> None:
     """
     Test the ss token.
     """
@@ -334,7 +335,7 @@ def test_ss_token():
     assert token.parse("59.123", tokens) == ({"second": 59}, ".123")
 
 
-def test_hplusduration_token():
+def test_hplusduration_token() -> None:
     """
     Test the [h+] token.
     """
@@ -372,7 +373,7 @@ def test_hplusduration_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_mplusduration_token():
+def test_mplusduration_token() -> None:
     """
     Test the [m+] token.
     """
@@ -416,7 +417,7 @@ def test_mplusduration_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_splusduration_token():
+def test_splusduration_token() -> None:
     """
     Test the [s+] token.
     """
@@ -463,7 +464,7 @@ def test_splusduration_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_d_token():
+def test_d_token() -> None:
     """
     Test the d token.
     """
@@ -483,7 +484,7 @@ def test_d_token():
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
 
-def test_dd_token():
+def test_dd_token() -> None:
     """
     Test the dd token.
     """
@@ -501,7 +502,7 @@ def test_dd_token():
     assert token.parse("12/11/2021", tokens) == ({"day": 12}, "/11/2021")
 
 
-def test_ddd_token():
+def test_ddd_token() -> None:
     """
     Test the ddd token.
     """
@@ -518,7 +519,7 @@ def test_ddd_token():
     assert token.parse("Fri, 12/11/2021", tokens) == ({"weekday": 0}, ", 12/11/2021")
 
 
-def test_ddddplus_token():
+def test_ddddplus_token() -> None:
     """
     Test the dddd+ token.
     """
@@ -535,7 +536,7 @@ def test_ddddplus_token():
     assert token.parse("Friday, 12/11/2021", tokens) == ({"weekday": 0}, ", 12/11/2021")
 
 
-def test_yy_token():
+def test_yy_token() -> None:
     """
     Test the yy token.
     """
@@ -552,7 +553,7 @@ def test_yy_token():
     assert token.parse("21/11/12", tokens) == ({"year": 2021}, "/11/12")
 
 
-def test_yyyy_token():
+def test_yyyy_token() -> None:
     """
     Test the yyyy token.
     """
@@ -569,7 +570,7 @@ def test_yyyy_token():
     assert token.parse("2021/11/12", tokens) == ({"year": 2021}, "/11/12")
 
 
-def test_zero_token():
+def test_zero_token() -> None:
     """
     Test the 00 token.
     """
@@ -591,7 +592,7 @@ def test_zero_token():
     assert token.parse("123", tokens) == ({"microsecond": 123000}, "")
 
 
-def test_ap_token():
+def test_ap_token() -> None:
     """
     Test the a/p token.
     """
@@ -615,7 +616,7 @@ def test_ap_token():
     assert token.parse("A 09:00", tokens) == ({"meridiem": Meridiem.AM}, " 09:00")
 
 
-def test_ampm_token():
+def test_ampm_token() -> None:
     """
     Test the am/pm token.
     """
@@ -635,7 +636,7 @@ def test_ampm_token():
     assert token.parse("AM 09:00", tokens) == ({"meridiem": Meridiem.AM}, " 09:00")
 
 
-def test_parse_date_time_pattern():
+def test_parse_date_time_pattern() -> None:
     """
     Test the parse_date_time_pattern function.
     """
@@ -672,7 +673,7 @@ def test_parse_date_time_pattern():
     assert str(excinfo.value) == "Unsupported format"
 
 
-def test_format_date_time_pattern():
+def test_format_date_time_pattern() -> None:
     """
     Test the format_date_time_pattern function.
     """
@@ -685,7 +686,7 @@ def test_format_date_time_pattern():
     )
 
 
-def test_parse_date_time_pattern_with_quotes():
+def test_parse_date_time_pattern_with_quotes() -> None:
     """
     Test parsing a timestamp with quotes.
     """
@@ -697,7 +698,7 @@ def test_parse_date_time_pattern_with_quotes():
     assert parsed == date(2021, 1, 1)
 
 
-def test_parse_date_time_with_meridiem():
+def test_parse_date_time_with_meridiem() -> None:
     """
     Test parsing a timestamp with AM/PM in the hour.
     """
@@ -716,7 +717,7 @@ def test_parse_date_time_with_meridiem():
     assert parsed == time(12, 34, 56)
 
 
-def test_parse_date_time_without_meridiem():
+def test_parse_date_time_without_meridiem() -> None:
     """
     Test parsing a timestamp without AM/PM in the hour.
     """
@@ -728,7 +729,7 @@ def test_parse_date_time_without_meridiem():
     assert parsed == datetime(2020, 12, 31, 12, 34, 56)
 
 
-def test_format_date_time_with_meridiem():
+def test_format_date_time_with_meridiem() -> None:
     """
     Test formatting a timestamp with AM/pM in the hour.
     """
@@ -739,3 +740,11 @@ def test_format_date_time_with_meridiem():
         )
         == "12:34:56 PM"
     )
+
+
+def test_infer_column_type() -> None:
+    """
+    Test type inferring via patterns.
+    """
+    assert infer_column_type("h:mm:ss am/pm") == "timeofday"
+    assert infer_column_type("[h]:mm:ss") == "duration"

--- a/tests/adapters/api/gsheets/parsing/number_test.py
+++ b/tests/adapters/api/gsheets/parsing/number_test.py
@@ -26,7 +26,7 @@ from shillelagh.adapters.api.gsheets.parsing.number import (
 )
 
 
-def test_digits_token():
+def test_digits_token() -> None:
     """
     Test the digits token.
     """
@@ -84,7 +84,7 @@ def test_digits_token():
     assert rest == ""
 
 
-def test_digits_errors():
+def test_digits_errors() -> None:
     """
     Test errors with the digits token.
     """
@@ -104,7 +104,7 @@ def test_digits_errors():
     assert str(excinfo.value) == "Invalid token: i"
 
 
-def test_period_token():
+def test_period_token() -> None:
     """
     Test the period token.
     """
@@ -119,7 +119,7 @@ def test_period_token():
     assert str(excinfo.value) == "invalid"
 
 
-def test_multiple_periods():
+def test_multiple_periods() -> None:
     """
     Test that only the first period is tokenized to a ``PERIOD``.
     """
@@ -134,7 +134,7 @@ def test_multiple_periods():
     ]
 
 
-def test_percent_token():
+def test_percent_token() -> None:
     """
     Test the percent token.
     """
@@ -149,7 +149,7 @@ def test_percent_token():
     assert str(excinfo.value) == "invalid"
 
 
-def test_comma_token():
+def test_comma_token() -> None:
     """
     Test the comma token.
     """
@@ -160,7 +160,7 @@ def test_comma_token():
     assert rest == ""
 
 
-def test_e_token():
+def test_e_token() -> None:
     """
     Test the scientific notation token.
     """
@@ -192,7 +192,7 @@ def test_e_token():
     assert str(excinfo.value) == "You are likely to be eaten by a grue."
 
 
-def test_fraction_token():
+def test_fraction_token() -> None:
     """
     Test the fraction token.
     """
@@ -218,7 +218,7 @@ def test_fraction_token():
     assert str(excinfo.value) == "You are likely to be eaten by a grue."
 
 
-def test_star_token():
+def test_star_token() -> None:
     """
     Test the star token.
     """
@@ -229,7 +229,7 @@ def test_star_token():
     assert rest == "1"
 
 
-def test_underscore_token():
+def test_underscore_token() -> None:
     """
     Test the underscore token.
     """
@@ -245,7 +245,7 @@ def test_underscore_token():
     assert str(excinfo.value) == "A"
 
 
-def test_at_token():
+def test_at_token() -> None:
     """
     Test the at token.
     """
@@ -266,7 +266,7 @@ def test_at_token():
     assert str(excinfo.value) == "123$"
 
 
-def test_color_token():
+def test_color_token() -> None:
     """
     Test the color token.
     """

--- a/tests/adapters/file/csvfile_test.py
+++ b/tests/adapters/file/csvfile_test.py
@@ -396,6 +396,18 @@ def test_cleanup(fs: FakeFilesystem, requests_mock: Mocker) -> None:
     assert not adapter.path.exists()
 
 
+def test_cleanup_file_deleted(fs: FakeFilesystem, requests_mock: Mocker) -> None:
+    """
+    Test that no exception is raised if local file is deleted.
+    """
+    requests_mock.get("https://example.com/test.csv", text=CONTENTS)
+
+    adapter = CSVFile("https://example.com/test.csv")
+    assert adapter.path.exists()
+    adapter.path.unlink()
+    adapter.close()
+
+
 def test_supports(fs: FakeFilesystem, requests_mock: Mocker) -> None:
     """
     Test the ``supports`` method.

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -320,7 +320,7 @@ def test_serialize() -> None:
     """
     assert serialize(["O'Malley's"]) == "2wEAAAD6Ck8nTWFsbGV5J3M="
 
-    def func():
+    def func() -> int:
         return 42
 
     with pytest.raises(ProgrammingError) as excinfo:
@@ -343,6 +343,7 @@ def test_combine_args_kwargs() -> None:
     """
     Test ``combine_args_kwargs``.
     """
+
     # pylint: disable=unused-argument, invalid-name
     def func(a: int = 0, b: str = "test", c: float = 10.0) -> None:
         pass


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Allow querying durations in Google sheets. For example:

```
sql> SELECT * FROM "https://docs.google.com/spreadsheets/d/1LcWZMsdCl92g7nA-D6qGRqg1T5TiHyuKJUY1u9XAnsk/edit#gid=1648320094";
datetime               number  boolean    date        timeofday    string    duration
-------------------  --------  ---------  ----------  -----------  --------  ----------
2018-09-01 00:00:00         1  True       2018-01-01  17:00:00     test      0:11:00
2018-09-02 00:00:00         1  False                               test      0:12:00
2018-09-03 00:00:00         2  False                               test
2018-09-04 00:00:00         3  False                               test
2018-09-05 00:00:00         5  False                               test
2018-09-06 00:00:00         8  False                               test
2018-09-07 00:00:00        13  False
2018-09-08 00:00:00            False                               test
2018-09-09 00:00:00        34                                      test
sql> SELECT duration FROM "https://docs.google.com/spreadsheets/d/1LcWZMsdCl92g7nA-D6qGRqg1T5TiHyuKJUY1u9XAnsk/edit#gid=1648320094" WHERE duration > '0:11:00';
duration
----------
0:12:00
sql>
```



# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
