### PR TITLE
fix: aggressive exception on missing operator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Fix unneeded error when an operators is not supported by adapter (#378)
+
 Version 1.2.6 - 2023-07-20
 ==========================
 

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -257,9 +257,6 @@ def get_bounds(
             if all(operator in class_.operators for operator in operators):
                 bounds[column_name] = class_.build(operations)
                 break
-        else:
-            # pylint: disable=broad-exception-raised
-            raise Exception("No valid filter found")
 
     return bounds
 

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -397,33 +397,33 @@ def test_cursor_with_constraints_invalid_filter() -> None:
 def test_cursor_with_constraints_no_filters() -> None:
     """
     Test passing a constraint to an adapter that cannot be filtered.
+
+    The filtering should be done by SQLite in this case.
     """
     table = VTTable(FakeAdapterNoFilters())
     cursor = table.Open()
-    with pytest.raises(Exception) as excinfo:
-        cursor.Filter(
-            42,
-            json.dumps({"indexes": [[1, 2]], "orderbys_to_process": []}),
-            ["Alice"],
-        )
-
-    assert str(excinfo.value) == "No valid filter found"
+    cursor.Filter(
+        42,
+        json.dumps({"indexes": [[1, 2]], "orderbys_to_process": []}),
+        ["Alice"],
+    )
+    assert cursor.current_row == (0, 20, "Alice", "0")
 
 
 def test_cursor_with_constraints_only_equal() -> None:
     """
     Test passing a constraint not supported by the adapter.
+
+    The filtering should be done by SQLite in this case.
     """
     table = VTTable(FakeAdapterOnlyEqual())
     cursor = table.Open()
-    with pytest.raises(Exception) as excinfo:
-        cursor.Filter(
-            42,
-            json.dumps({"indexes": [[1, 32]], "orderbys_to_process": []}),
-            ["Alice"],
-        )
-
-    assert str(excinfo.value) == "No valid filter found"
+    cursor.Filter(
+        42,
+        json.dumps({"indexes": [[1, 32]], "orderbys_to_process": []}),
+        ["Alice"],
+    )
+    assert cursor.current_row == (0, 20, "Alice", "0")
 
 
 def test_adapter_with_no_columns() -> None:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

When an adapter doesn't support a given operator (say, `LIKE`) we were raising an exception. Instead, we can delegate to SQLite the work of doing the filtering by simply not raising the exception.

Fixes #376.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
