### PR TITLE
fix: `importlib_metadata` on newer CPython

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Contributors
 * Alex Rothberg <agrothberg@gmail.com>
 * Elias Sebbar <contact@eliassebbar.info>
 * Arash Afghahi <arash.afghahi@gmail.com>
+* Samuel Giffard <samuel@giffard.co>

--- a/src/shillelagh/adapters/registry.py
+++ b/src/shillelagh/adapters/registry.py
@@ -5,13 +5,19 @@ Inspired by SQLAlchemy's ``PluginLoader``.
 """
 
 import logging
+import sys
 from collections import defaultdict
 from typing import Dict, List, Optional, Type, cast
 
-from importlib_metadata import entry_points
-
 from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import InterfaceError
+
+if sys.version_info < (3, 10):
+    # Use the backport library because it provides a forward-compatible
+    # implementation.
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 _logger = logging.getLogger(__name__)
 

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -2,13 +2,19 @@
 Custom functions available to the SQL backend.
 """
 import json
+import sys
 import time
 from typing import Any, Dict, List, Type
 
-from importlib_metadata import distribution
-
 from shillelagh.adapters.base import Adapter
 from shillelagh.lib import find_adapter
+
+if sys.version_info < (3, 10):
+    # Use the backport library because it provides a forward-compatible
+    # implementation.
+    from importlib_metadata import distribution
+else:
+    from importlib.metadata import distribution
 
 __all__ = ["sleep", "get_metadata", "version"]
 


### PR DESCRIPTION
In Python 3.11, the library will fail with
```
ModuleNotFoundError: No module named 'importlib_metadata'
```

This PR aims at making it compatible for both older CPython versions as well as newer ones.

# Summary

Fixes #384 

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
