### PR TITLE
fix: datassette detection and JSON parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Next
 ====
 
+- Improve Datasette detection (#399)
+- Fix generic JSON handling of null values (#399)
+
 Version 1.2.8 - 2023-10-21
 ==========================
 

--- a/src/shillelagh/adapters/api/datasette.py
+++ b/src/shillelagh/adapters/api/datasette.py
@@ -59,8 +59,13 @@ def is_datasette(uri: str) -> bool:
         expire_after=180,
     )
 
-    response = session.head(uri)
-    return cast(bool, response.ok)
+    response = session.get(uri)
+    try:
+        payload = response.json()
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+
+    return "datasette" in payload
 
 
 def get_field(value: Any) -> Field:

--- a/src/shillelagh/adapters/api/generic_json.py
+++ b/src/shillelagh/adapters/api/generic_json.py
@@ -140,7 +140,7 @@ class GenericJSONAPI(Adapter):
         for i, row in enumerate(parser.parse(payload)):
             row = {
                 k: v
-                for k, v in row.items()
+                for k, v in (row or {}).items()
                 if requested_columns is None or k in requested_columns
             }
             row["rowid"] = i

--- a/tests/adapters/api/datasette_test.py
+++ b/tests/adapters/api/datasette_test.py
@@ -249,7 +249,7 @@ def test_is_datasette(requests_mock: Mocker) -> None:
     """
     assert not is_datasette("https://example.com/")
 
-    requests_mock.head(
+    requests_mock.get(
         "https://example.com/-/versions.json",
         json={
             "python": {
@@ -288,6 +288,12 @@ def test_is_datasette(requests_mock: Mocker) -> None:
             },
             "pysqlite3": "0.4.6",
         },
+    )
+    assert is_datasette("https://example.com/database/table")
+
+    requests_mock.get(
+        "https://example.com/-/versions.json",
+        text="Invalid page",
     )
     assert is_datasette("https://example.com/database/table")
 

--- a/tests/adapters/api/generic_json_test.py
+++ b/tests/adapters/api/generic_json_test.py
@@ -2,6 +2,7 @@
 Test the generic JSON adapter.
 """
 
+import re
 from datetime import timedelta
 
 import pytest
@@ -25,14 +26,8 @@ def test_generic_json(mocker: MockerFixture, requests_mock: Mocker) -> None:
     """
     mocker.patch("shillelagh.adapters.api.generic_json.CACHE_EXPIRATION", DO_NOT_CACHE)
 
-    # for datassette and other probing adapters
-    requests_mock.head(
-        "https://api.stlouisfed.org/-/versions.json?"
-        "series_id=GNPCA&"
-        "api_key=abcdefghijklmnopqrstuvwxyz123456&"
-        "file_type=json#$.seriess%5B*%5D",
-        status_code=404,
-    )
+    # for datassette
+    requests_mock.get(re.compile(".*-/versions.json.*"), status_code=404)
 
     params = {
         "series_id": "GNPCA",

--- a/tests/adapters/api/generic_xml_test.py
+++ b/tests/adapters/api/generic_xml_test.py
@@ -47,7 +47,8 @@ def test_generic_xml(mocker: MockerFixture, requests_mock: Mocker) -> None:
     """
     mocker.patch("shillelagh.adapters.api.generic_json.CACHE_EXPIRATION", DO_NOT_CACHE)
 
-    requests_mock.head(re.compile(".*-/versions.json.*"), status_code=404)
+    # for datassette
+    requests_mock.get(re.compile(".*-/versions.json.*"), status_code=404)
 
     params = {
         "format": "Xml",


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

The `supports` method in the Datassette adapter was too aggressive. This PR modifies it to be more conservative.

Also fix the generic JSON adapter to handle null values.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
