### PR TITLE
fix: No module named 'requests_cache'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,7 @@ console =
     appdirs>=1.4.4
     prompt_toolkit>=3
     pygments>=2.8
+    requests-cache>=0.7.1
     tabulate==0.8.9
 datasetteapi =
     requests-cache>=0.7.1


### PR DESCRIPTION
Installing just the CLI via `pip install 'shillelagh[console]'` results
in a non-function CLI, due to missing requests-cache third party libary.

fixes #400
