### PR TITLE
fix: allow Preset handler to query workspaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Preset adapter can now query workspaces (#422)
+
 Version 1.2.13 - 2024-01-04
 ===========================
 

--- a/src/shillelagh/adapters/api/preset.py
+++ b/src/shillelagh/adapters/api/preset.py
@@ -38,7 +38,9 @@ class PresetAPI(GenericJSONAPI):
     @classmethod
     def supports(cls, uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
         parsed = URL(uri)
-        return parsed.scheme in ("http", "https") and parsed.host == "api.app.preset.io"
+        return parsed.scheme in ("http", "https") and (
+            parsed.host == "preset.io" or parsed.host.endswith(".preset.io")
+        )
 
     def __init__(
         self,

--- a/tests/adapters/api/preset_test.py
+++ b/tests/adapters/api/preset_test.py
@@ -71,3 +71,11 @@ def test_supports() -> None:
     assert PresetAPI.supports("/etc/password") is False
     assert PresetAPI.supports("https://example.org/data.html") is False
     assert PresetAPI.supports("https://api.app.preset.io/v1/teams/") is True
+    assert (
+        PresetAPI.supports(
+            "https://db64ce64.us1a.app-sdx.preset.io/sqllab/?savedQueryId=1",
+        )
+        is True
+    )
+    assert PresetAPI.supports("https://preset.io/") is True
+    assert PresetAPI.supports("https://phishingpreset.io/") is False


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
