### PR TITLE
feat: add CVE, CPE and CWE from NVD Apis adapters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -151,6 +151,9 @@ systemapi =
 # Add here console scripts like:
 shillelagh.adapter =
     csvfile = shillelagh.adapters.file.csvfile:CSVFile
+    cves = shillelagh.adapters.api.cves:CvesAPI
+    cpes = shillelagh.adapters.api.cpes:CpesAPI
+    cwes = shillelagh.adapters.api.cwes:CwesAPI
     datasetteapi = shillelagh.adapters.api.datasette:DatasetteAPI
     genericjsonapi = shillelagh.adapters.api.generic_json:GenericJSONAPI
     genericxmlapi = shillelagh.adapters.api.generic_xml:GenericXMLAPI

--- a/src/shillelagh/adapters/api/cpes.py
+++ b/src/shillelagh/adapters/api/cpes.py
@@ -1,0 +1,206 @@
+"""
+An adapter to CPEs API. https://nvd.nist.gov/developers/vulnerabilities
+"""
+import logging
+import urllib.parse
+from collections import namedtuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
+
+import dateutil.parser
+import dateutil.tz
+import requests_cache
+
+from shillelagh.adapters.base import Adapter
+from shillelagh.exceptions import ImpossibleFilterError
+from shillelagh.fields import DateTime, String
+from shillelagh.filters import Equal, Filter, Operator
+from shillelagh.typing import RequestedOrder, Row
+
+_logger = logging.getLogger(__name__)
+
+INITIAL_COST = 0
+FETCHING_COST = 1000
+PAGE_SIZE = 100
+
+CpeItem = namedtuple(
+    "CpeItem",
+    [
+        "vendor",
+        "product",
+        "version",
+        "update",
+    ],
+)
+
+
+def get_cpe_from_items(
+    vendor: str = "*",
+    product: str = "*",
+    version: str = "*",
+    update: str = "*",
+) -> str:
+    """
+    Generate a CPE from a CPE item.
+
+    The CPE is a string with the following format:
+
+    cpe:2.3:a:vendor:product:version:update:edition:language:sw_edition:target_sw:target_hw:other
+
+    This function generates a CPE from a CPE items.
+    """
+    return f"cpe:2.3:a:{vendor}:{product}:{version}:{update}:*:*"
+
+
+def get_cpe_item_from_cpe(cpe: str) -> CpeItem:
+    """
+    Split a CPE into its components.
+
+    The CPE is a string with the following format:
+
+    cpe:2.3:a:vendor:product:version:update:edition:language:sw_edition:target_sw:target_hw:other
+
+    This function splits the CPE into its components and returns a tuple with the
+    components.
+    """
+    parts = cpe.split(":")
+    return CpeItem(parts[3], parts[4], parts[5], parts[6])
+
+
+def parse_raw_cpe_item(cpe_item: Dict[str, Any]) -> Row:
+    """
+    Helper method to parse a RAW cpe_item from the API into a row
+    """
+    row: Row = {}
+    row["cpe_name"] = cpe_item["cpeName"]
+    row["cpe_name_id"] = cpe_item["cpeNameId"]
+    row["last_modified"] = dateutil.parser.parse(cpe_item["lastModified"]).replace(
+        tzinfo=dateutil.tz.UTC,
+    )
+    row["created"] = dateutil.parser.parse(cpe_item["created"]).replace(
+        tzinfo=dateutil.tz.UTC,
+    )
+    row["title"] = cpe_item["titles"][0]["title"]
+    row["vendor"], row["product"], _, _ = get_cpe_item_from_cpe(
+        cpe_item["cpeName"],
+    )
+
+    return row
+
+
+class CpesAPI(Adapter):
+
+    """
+    An adapter for NVD CPES REST Api (https://services.nvd.nist.gov/rest/json/).
+
+    The adapter expects an URL like::
+
+        cpes://
+    """
+
+    safe = True
+
+    supports_limit = False
+    supports_offset = False
+
+    cpe_name = String()
+    cpe_name_id = String()
+    last_modified = DateTime()
+    created = DateTime()
+    title = String()
+    vendor = String(filters=[Equal], exact=True)
+    product = String(filters=[Equal], exact=True)
+    version = String()
+    update = String()
+
+    @staticmethod
+    def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
+        """cpes://"""
+        parsed = urllib.parse.urlparse(uri)
+        return parsed.scheme == "cpes"
+
+    @staticmethod
+    def parse_uri(uri: str) -> Tuple[str, ...]:
+        parsed = urllib.parse.urlparse(uri)
+        query_string = urllib.parse.parse_qs(parsed.query)
+        # key can be passed in the URL or via connection arguments
+        if "api_key" in query_string:
+            return (query_string["api_key"][0],)
+        return tuple()
+
+    def __init__(self, api_key: Optional[str] = None, window: int = PAGE_SIZE):
+        super().__init__()
+
+        self._url = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
+        self.api_key = api_key
+        self.window = window
+
+        # use a cache, since the adapter does a lot of similar API requests,
+        # and the data should rarely (never?) change
+        self._session = requests_cache.CachedSession(
+            cache_name="cpes_cache",
+            backend="sqlite",
+            expire_after=1800,
+        )
+
+    def get_cost(
+        self,
+        filtered_columns: List[Tuple[str, Operator]],
+        order: List[Tuple[str, RequestedOrder]],
+    ) -> float:
+        cost = INITIAL_COST
+
+        # if the operator is ``Operator.EQ`` we only need to fetch 1 day of data;
+        # otherwise we potentially need to fetch "window" days of data
+        for _, operator in filtered_columns:
+            weight = 1 if operator == Operator.EQ else self.window
+            cost += FETCHING_COST * weight
+
+        return cost
+
+    def _build_url_params(self, bounds: Dict[str, Filter], offset=0) -> Dict[str, str]:
+        # Handle pagination
+        params = {"resultsPerPage": self.window, "startIndex": offset}
+        # handles Filters
+        vendor = (
+            cast(Equal, bounds.get("vendor", Equal)).value
+            if "vendor" in bounds
+            else "*"
+        )
+        product = (
+            cast(Equal, bounds.get("product", Equal)).value
+            if "product" in bounds
+            else "*"
+        )
+        params["cpeMatchString"] = get_cpe_from_items(vendor, product)
+        return params
+
+    def get_data(
+        self,
+        bounds: Dict[str, Filter],
+        order: List[Tuple[str, RequestedOrder]],
+        **kwargs: Any,
+    ) -> Iterator[Row]:
+        offset = 0
+        total_results = None
+
+        while True:
+            try:
+                params = self._build_url_params(bounds, offset)
+            except ImpossibleFilterError:
+                return
+
+            query_string = urllib.parse.urlencode(params)
+            _logger.info("GET %s?%s", self._url, query_string)
+
+            response = self._session.get(self._url, params=params)
+            if not response.ok:
+                return
+            payload = response.json()
+            for cpe_item in payload["products"]:
+                yield parse_raw_cpe_item(cpe_item["cpe"])
+
+            offset += self.window
+            if total_results is not None and offset >= total_results:
+                break
+            if total_results is None and len(payload["products"]) < self.window:
+                break

--- a/src/shillelagh/adapters/api/cves.py
+++ b/src/shillelagh/adapters/api/cves.py
@@ -1,0 +1,189 @@
+"""
+An adapter to CVEs API. https://nvd.nist.gov/developers/vulnerabilities
+"""
+import logging
+import urllib.parse
+from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
+
+import dateutil.parser
+import dateutil.tz
+import requests_cache
+
+from shillelagh.adapters.api.cpes import get_cpe_from_items, get_cpe_item_from_cpe
+from shillelagh.adapters.base import Adapter
+from shillelagh.exceptions import ImpossibleFilterError
+from shillelagh.fields import DateTime, Float, String
+from shillelagh.filters import Equal, Filter, Operator
+from shillelagh.typing import RequestedOrder, Row
+
+_logger = logging.getLogger(__name__)
+
+INITIAL_COST = 0
+FETCHING_COST = 1000
+PAGE_SIZE = 1000
+
+
+def parse_raw_cve_item(cve_item: Dict[str, Any]) -> Row:
+    """
+    Helper method to parse a RAW cve_item from the API into a row
+    """
+    row: Row = {}
+
+    # Converges both CVSS v2 and v3 into a single score and vector
+    row["cvss_score"] = float(
+        cve_item["metrics"]["cvssMetricV31"][0]["cvssData"]["baseScore"]
+        if "cvssMetricV31" in cve_item["metrics"]
+        else cve_item["metrics"]["cvssMetricV2"][0]["cvssData"]["baseScore"]
+        if "cvssMetricV2" in cve_item["metrics"]
+        else 0.0,
+    )
+    row["cvss_vector"] = (
+        cve_item["metrics"]["cvssMetricV31"][0]["cvssData"]["vectorString"]
+        if "cvssMetricV31" in cve_item["metrics"]
+        else cve_item["metrics"]["cvssMetricV2"][0]["cvssData"]["vectorString"]
+        if "cvssMetricV2" in cve_item["metrics"]
+        else ""
+    )
+    row["cve_id"] = cve_item["id"]
+    row["status"] = cve_item["vulnStatus"]
+    row["description"] = cve_item["descriptions"][0]["value"]
+    row["published_date"] = dateutil.parser.parse(cve_item["published"]).replace(
+        tzinfo=dateutil.tz.UTC,
+    )
+    row["last_modified_date"] = dateutil.parser.parse(
+        cve_item["lastModified"],
+    ).replace(
+        tzinfo=dateutil.tz.UTC,
+    )
+    row["cwe_id"] = cve_item["weaknesses"][0]["description"][0]["value"]
+    if "configurations" in cve_item:
+        cpe = cve_item["configurations"][0]["nodes"][0]["cpeMatch"][0]["criteria"]
+        row["vendor"], row["product"], _, _ = get_cpe_item_from_cpe(
+            cpe,
+        )
+    return row
+
+
+class CvesAPI(Adapter):
+
+    """
+    An adapter for NVD CVES REST Api (https://services.nvd.nist.gov/rest/json/).
+
+    The adapter expects an URL like::
+
+        cves://
+    """
+
+    safe = True
+
+    supports_limit = False
+    supports_offset = False
+
+    cve_id = String(filters=[Equal], exact=True)
+    cwe_id = String(filters=[Equal], exact=True)
+    cwe_name = String()
+    cvss_score = Float()
+    status = String()
+    cvss_vector = String()
+    description = String()
+    published_date = DateTime()
+    last_modified_date = DateTime()
+    vendor = String(filters=[Equal], exact=True)
+    product = String(filters=[Equal], exact=True)
+
+    @staticmethod
+    def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
+        """cves://"""
+        parsed = urllib.parse.urlparse(uri)
+        return parsed.scheme == "cves"
+
+    @staticmethod
+    def parse_uri(uri: str) -> Tuple[str, ...]:
+        parsed = urllib.parse.urlparse(uri)
+        query_string = urllib.parse.parse_qs(parsed.query)
+        # key can be passed in the URL or via connection arguments
+        if "api_key" in query_string:
+            return (query_string["api_key"][0],)
+        return tuple()
+
+    def __init__(self, api_key: Optional[str] = None, window: int = PAGE_SIZE):
+        super().__init__()
+
+        self._url = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+        self.api_key = api_key
+        self.window = window
+
+        # use a cache, since the adapter does a lot of similar API requests,
+        # and the data should rarely (never?) change
+        self._session = requests_cache.CachedSession(
+            cache_name="cves_cache",
+            backend="sqlite",
+            expire_after=180,
+        )
+
+    def get_cost(
+        self,
+        filtered_columns: List[Tuple[str, Operator]],
+        order: List[Tuple[str, RequestedOrder]],
+    ) -> float:
+        cost = INITIAL_COST
+
+        # if the operator is ``Operator.EQ`` we only need to fetch 1 day of data;
+        # otherwise we potentially need to fetch "window" days of data
+        for _, operator in filtered_columns:
+            weight = 1 if operator == Operator.EQ else self.window
+            cost += FETCHING_COST * weight
+
+        return cost
+
+    def _build_url_params(self, bounds: Dict[str, Filter], offset=0) -> Dict[str, str]:
+        # Handle pagination
+        params = {"resultsPerPage": self.window, "startIndex": offset}
+        # handles Filters
+        if "cve_id" in bounds:
+            params["CveId"] = cast(Equal, bounds.get("cve_id", Equal)).value
+        vendor = (
+            cast(Equal, bounds.get("vendor", Equal)).value
+            if "vendor" in bounds
+            else "*"
+        )
+        product = (
+            cast(Equal, bounds.get("product", Equal)).value
+            if "product" in bounds
+            else "*"
+        )
+        params["virtualMatchString"] = get_cpe_from_items(vendor, product)
+        if "cwe_id" in bounds:
+            params["cweID"] = cast(Equal, bounds.get("cwe_id", Equal)).value
+        return params
+
+    def get_data(
+        self,
+        bounds: Dict[str, Filter],
+        order: List[Tuple[str, RequestedOrder]],
+        **kwargs: Any,
+    ) -> Iterator[Row]:
+        offset = 0
+        total_results = None
+
+        while True:
+            try:
+                params = self._build_url_params(bounds, offset)
+            except ImpossibleFilterError:
+                return
+
+            query_string = urllib.parse.urlencode(params)
+            _logger.info("GET %s?%s", self._url, query_string)
+
+            response = self._session.get(self._url, params=params)
+            if not response.ok:
+                return
+            payload = response.json()
+            for cve_item in payload["vulnerabilities"]:
+                yield parse_raw_cve_item(cve_item["cve"])
+
+            offset += self.window
+            if total_results is not None and offset >= total_results:
+                break
+            if total_results is None and len(payload["vulnerabilities"]) < self.window:
+                break

--- a/src/shillelagh/adapters/api/cwes.py
+++ b/src/shillelagh/adapters/api/cwes.py
@@ -33,13 +33,6 @@ class CwesAPI(Adapter):
     supports_limit = False
     supports_offset = False
 
-    # These two columns can be used to filter the results from the API. We
-    # define them as inexact since we will retrieve data for the whole day,
-    # even if specific hours are requested. The post-filtering will be done
-    # by the backend.
-    # time = DateTime(filters=[Range], order=Order.ASCENDING, exact=False)
-    # time_epoch = Float(filters=[Range], order=Order.ASCENDING, exact=False)
-
     cwe_id = String()
     description = String()
 

--- a/src/shillelagh/adapters/api/cwes.py
+++ b/src/shillelagh/adapters/api/cwes.py
@@ -1,0 +1,86 @@
+"""
+An adapter to CWEs.
+"""
+import logging
+import urllib.parse
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import requests_cache
+
+from shillelagh.adapters.base import Adapter
+from shillelagh.fields import String
+from shillelagh.filters import Filter
+from shillelagh.typing import RequestedOrder, Row
+
+_logger = logging.getLogger(__name__)
+
+INITIAL_COST = 0
+FETCHING_COST = 1000
+
+
+class CwesAPI(Adapter):
+
+    """
+    An adapter for CWEs JSON (https://github.com/OWASP/cwe-sdk-javascript).
+
+    The adapter expects an URL like::
+
+        cwes://
+    """
+
+    safe = True
+
+    supports_limit = False
+    supports_offset = False
+
+    # These two columns can be used to filter the results from the API. We
+    # define them as inexact since we will retrieve data for the whole day,
+    # even if specific hours are requested. The post-filtering will be done
+    # by the backend.
+    # time = DateTime(filters=[Range], order=Order.ASCENDING, exact=False)
+    # time_epoch = Float(filters=[Range], order=Order.ASCENDING, exact=False)
+
+    cwe_id = String()
+    description = String()
+
+    @staticmethod
+    def supports(uri: str, fast: bool = True, **kwargs: Any) -> Optional[bool]:
+        """cwes://"""
+        parsed = urllib.parse.urlparse(uri)
+        return parsed.scheme == "cwes"
+
+    @staticmethod
+    def parse_uri(uri: str) -> Tuple[None, ...]:
+        return tuple()
+
+    def __init__(self):
+        super().__init__()
+        self._url = (
+            "https://raw.githubusercontent.com/OWASP/"
+            "cwe-sdk-javascript/master/raw/cwe-dictionary.json"
+        )
+
+        # use a cache, since the adapter does a lot of similar API requests,
+        # and the data should rarely (never?) change
+        self._session = requests_cache.CachedSession(
+            cache_name="cwes_cache",
+            backend="sqlite",
+            expire_after=1800,
+        )
+
+    def get_data(  # pylint: disable=too-many-locals
+        self,
+        bounds: Dict[str, Filter],
+        order: List[Tuple[str, RequestedOrder]],
+        **kwargs: Any,
+    ) -> Iterator[Row]:
+        response = self._session.get(self._url)
+        if not response.ok:
+            return
+        payload = response.json()
+        for cwe_id, item in payload.items():
+            row = {
+                "cwe_id": f"CWE-{cwe_id}",
+                "description": item["Description"],
+            }
+            yield row


### PR DESCRIPTION
# Summary

New adapter proposal to support CVE, CPES and CWEs from NVD as a datasource.

Will consume 2 REST API endpoints from NVD, more details here: https://nvd.nist.gov/developers

for the CVES: https://nvd.nist.gov/developers/vulnerabilities
for the CPES: https://nvd.nist.gov/developers/products

Will allow for queries like (joining CVES and CWES):

```
SELECT 
  v.published_date,
  v.cve_id, 
  v.cwe_id, 
  v.cvss_score, 
  v.vendor,
  v.product,
  v.status,
  v.description, 
  w.description AS cwe_description,
  v.last_modified_date
FROM "cves://" AS v
LEFT JOIN "cwes://" AS w ON v.cwe_id = w.cwe_id
where v.vendor = "apache" and v.product = "superset"
```

<img width="1310" alt="Screenshot 2024-02-08 at 14 28 28" src="https://github.com/betodealmeida/shillelagh/assets/4025227/f9981569-6f06-4dae-ae67-1043dcf77cbe">

Still missing tests, tell me if this sounds interesting to you @betodealmeida, or if it makes sense to add it directly to `shillelagh`

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
