### PR TITLE
fix(gsheets): handle getting values from rows in wide tables

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Contributors
 * Alex Rothberg <agrothberg@gmail.com>
 * Elias Sebbar <contact@eliassebbar.info>
 * Arash Afghahi <arash.afghahi@gmail.com>
+* Johannes Körner <johannes.koerner@me.com>

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -206,7 +206,7 @@ def get_values_from_row(row: Row, column_map: Dict[str, str]) -> List[Any]:
         >>> get_values_from_row(row, column_map)
         ['BR', '', 10]
     """
-    n_cols = get_index_from_letters(max(column_map.values())) + 1
+    n_cols = max([get_index_from_letters(val) for val in column_map.values()]) + 1
     row = {column_map[k]: v for k, v in row.items() if k in column_map}
     return [row.get(column, "") for column in itertools.islice(gen_letters(), n_cols)]
 

--- a/src/shillelagh/adapters/api/gsheets/lib.py
+++ b/src/shillelagh/adapters/api/gsheets/lib.py
@@ -206,7 +206,7 @@ def get_values_from_row(row: Row, column_map: Dict[str, str]) -> List[Any]:
         >>> get_values_from_row(row, column_map)
         ['BR', '', 10]
     """
-    n_cols = max([get_index_from_letters(val) for val in column_map.values()]) + 1
+    n_cols = max(get_index_from_letters(val) for val in column_map.values()) + 1
     row = {column_map[k]: v for k, v in row.items() if k in column_map}
     return [row.get(column, "") for column in itertools.islice(gen_letters(), n_cols)]
 

--- a/tests/adapters/api/gsheets/lib_test.py
+++ b/tests/adapters/api/gsheets/lib_test.py
@@ -270,9 +270,9 @@ def test_get_values_from_row() -> None:
     """
     Test ``get_values_from_row``.
     """
-    column_map = {"country": "A", "cnt": "C"}
+    column_map = {"country": "Z", "cnt": "AB"}
     row = {"country": "BR", "cnt": 10}
-    assert get_values_from_row(row, column_map) == ["BR", "", 10]
+    assert get_values_from_row(row, column_map) == 25 * [""] + ["BR", "", 10]
 
 
 def test_get_credentials(mocker: MockerFixture):

--- a/tests/adapters/api/gsheets/lib_test.py
+++ b/tests/adapters/api/gsheets/lib_test.py
@@ -272,7 +272,7 @@ def test_get_values_from_row() -> None:
     """
     column_map = {"country": "Z", "cnt": "AB"}
     row = {"country": "BR", "cnt": 10}
-    assert get_values_from_row(row, column_map) == 25 * [""] + ["BR", "", 10]
+    assert get_values_from_row(row, column_map) == 25 * [""] + ["BR", "", 10]  # type: ignore
 
 
 def test_get_credentials(mocker: MockerFixture):


### PR DESCRIPTION
# Summary
`get_values_from_row` had a flaw that would result in a wrong value for `n_cols` under certain conditions. `n_cols` is expected to be the result of `get_index_from_letters` for the "highest letter" column. However, using `max` to get the "highest letter" column is not feasible as `max("Z", "AA") == "Z"`.
To fix this, `get_index_from_letters` is called on all values of `column_map` to make sure that we find the correct `n_cols`.

# Testing instructions
The unit test for `get_values_from_row` have been updated to cover this change as well.
