### PR TITLE
feat: allow defining the cache timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Allow for custom expiration time in the generic JSON/XML adapters (#429)
+
 Version 1.2.15 - 2024-02-13
 ===========================
 

--- a/src/shillelagh/adapters/api/generic_json.py
+++ b/src/shillelagh/adapters/api/generic_json.py
@@ -59,7 +59,15 @@ class GenericJSONAPI(Adapter):
         else:
             request_headers = kwargs.get("request_headers", {})
 
-        session = get_session(request_headers, cls.cache_name, CACHE_EXPIRATION)
+        cache_expiration = kwargs.get(
+            "cache_expiration",
+            CACHE_EXPIRATION.total_seconds(),
+        )
+        session = get_session(
+            request_headers,
+            cls.cache_name,
+            timedelta(seconds=cache_expiration),
+        )
         response = session.head(str(parsed))
         return cls.content_type in response.headers.get("content-type", "")
 
@@ -87,6 +95,7 @@ class GenericJSONAPI(Adapter):
         uri: str,
         path: Optional[str] = None,
         request_headers: Optional[Dict[str, str]] = None,
+        cache_expiration: float = CACHE_EXPIRATION.total_seconds(),
     ):
         super().__init__()
 
@@ -96,7 +105,7 @@ class GenericJSONAPI(Adapter):
         self._session = get_session(
             request_headers or {},
             self.cache_name,
-            CACHE_EXPIRATION,
+            timedelta(seconds=cache_expiration),
         )
 
         self._set_columns()


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Allow passing a timeout in seconds to the JSON/XML/Preset adapters.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
