### PR TITLE
fix: use better JSONPath library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next
 ====
 
 - Allow for custom expiration time in the generic JSON/XML adapters (#429)
+- Use a different JSONPath library that handles root better (#431)
 
 Version 1.2.15 - 2024-02-13
 ===========================

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -86,8 +86,6 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonpath-python==1.0.6
-    # via shillelagh
 lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.7.0
@@ -156,6 +154,8 @@ python-dateutil==2.8.2
     #   holidays
     #   pandas
     #   shillelagh
+python-jsonpath==0.10.3
+    # via shillelagh
 pytz==2022.1
     # via pandas
 pyyaml==6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ testing =
     google-auth>=1.23.0
     holidays>=0.23
     html5lib>=1.1
-    jsonpath-python>=1.0.5
     pandas>=1.2.2
     pip-tools>=6.4.0
     pre-commit>=2.13.0
@@ -94,6 +93,7 @@ testing =
     pytest-integration==0.2.2
     pytest-mock>=3.5.1
     pytest>=7.2.0
+    python-jsonpath>=0.10.3
     requests-mock>=1.8.0
     tabulate==0.8.9
     yarl>=1.8.1
@@ -106,12 +106,12 @@ all =
     google-auth>=1.23.0
     holidays>=0.23
     html5lib>=1.1
-    jsonpath-python>=1.0.5
     pandas>=1.2.2
     prison>=0.2.1
     prompt_toolkit>=3
     psutil>=5.8.0
     pygments>=2.8
+    python-jsonpath>=0.10.3
     tabulate==0.8.9
     yarl>=1.8.1
 docs =
@@ -123,15 +123,15 @@ console =
     pygments>=2.8
     tabulate==0.8.9
 genericjsonapi =
-    jsonpath-python>=1.0.5
     prison>=0.2.1
+    python-jsonpath>=0.10.3
     yarl>=1.8.1
 genericxmlapi =
     defusedxml>=0.7.1
     prison>=0.2.1
     yarl>=1.8.1
 githubapi =
-    jsonpath-python>=1.0.5
+    python-jsonpath>=0.10.3
 gsheetsapi =
     google-auth>=1.23.0
 holidaysmemory =

--- a/src/shillelagh/adapters/api/generic_json.py
+++ b/src/shillelagh/adapters/api/generic_json.py
@@ -8,8 +8,8 @@ import logging
 from datetime import timedelta
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
+import jsonpath
 import prison
-from jsonpath import JSONPath
 from yarl import URL
 
 from shillelagh.adapters.base import Adapter
@@ -145,8 +145,7 @@ class GenericJSONAPI(Adapter):
         if not response.ok:
             raise ProgrammingError(f'Error: {payload["message"]}')
 
-        parser = JSONPath(self.path)
-        for i, row in enumerate(parser.parse(payload)):
+        for i, row in enumerate(jsonpath.findall(self.path, payload)):
             row = {
                 k: v
                 for k, v in (row or {}).items()

--- a/src/shillelagh/adapters/api/github.py
+++ b/src/shillelagh/adapters/api/github.py
@@ -6,8 +6,8 @@ import urllib.parse
 from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+import jsonpath
 import requests_cache
-from jsonpath import JSONPath
 
 from shillelagh.adapters.base import Adapter
 from shillelagh.exceptions import ProgrammingError
@@ -177,7 +177,7 @@ class GitHubAPI(Adapter):
         payload = response.json()
 
         row = {
-            column.name: JSONPath(column.json_path).parse(payload)[0]
+            column.name: jsonpath.findall(column.json_path, payload)[0]
             for column in TABLES[self.base][self.resource]
         }
         row["rowid"] = 0
@@ -231,7 +231,7 @@ class GitHubAPI(Adapter):
                     break
 
                 row = {
-                    column.name: JSONPath(column.json_path).parse(resource)[0]
+                    column.name: jsonpath.findall(column.json_path, resource)[0]
                     for column in TABLES[self.base][self.resource]
                 }
                 row["rowid"] = rowid

--- a/src/shillelagh/adapters/api/preset.py
+++ b/src/shillelagh/adapters/api/preset.py
@@ -8,9 +8,9 @@ import logging
 import re
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, cast
 
+import jsonpath
 import prison
 import requests
-from jsonpath import JSONPath
 from yarl import URL
 
 from shillelagh.adapters.api.generic_json import CACHE_EXPIRATION, GenericJSONAPI
@@ -178,8 +178,7 @@ class PresetWorkspaceAPI(PresetAPI):
                 )
                 raise ProgrammingError(f"Error: {messages}")
 
-            parser = JSONPath(self.path)
-            rows = parser.parse(payload)[slice_]
+            rows = jsonpath.findall(self.path, payload)[slice_]
             if not rows:
                 break
 


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Use `python-jsonpath` instead of `jsonpath-python`, since it handles the root (`$`) better.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
