### PR TITLE
fix(cookiecutter): adapter_type to lowercase

### DIFF
--- a/templates/adapter/cookiecutter.json
+++ b/templates/adapter/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "adapter_name": "MyAdapter",
     "description": "An adapter for ...",
-    "adapter_type": ["API", "File", "Memory"],
+    "adapter_type": ["api", "file", "memory"],
     "slug": "{{ cookiecutter.adapter_name|lower|replace(' ', '-') }}"
 }


### PR DESCRIPTION
# Summary
Fixes #441.

This makes the `adapter_type` in `cookiecutter.json` to lowercase so that it matches the adapter directory names and make the script `post_gen_project.sh` work.

# Testing instructions

```bash
$ git clone https://github.com/betodealmeida/shillelagh.git
$ cd shillelagh
$ python -m venv venv
$ source venv/bin/activate
$ python -m pip install cookiecutter
$ cookiecutter templates/adapter/
```