### PR TITLE
chore: relax tabulate dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Relax ``tabulate`` dependency for Apache Superset (#443)
+
 Version 1.2.18 - 2024-03-27
 ===========================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ all =
     psutil>=5.8.0
     pygments>=2.8
     python-jsonpath>=0.10.3
-    tabulate==0.8.9
+    tabulate>=0.8.9
     yarl>=1.8.1
 docs =
     sphinx>=4.0.1


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

In current Superset master, there is now a [bump](https://github.com/apache/superset/pull/27733) for ``tabulate`` from ``0.8.9`` to ``0.8.10``. Relaxing the required version since Superset 4.0 still doesn't depend on this bump.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
