### PR TITLE
Add import_dbapi() to mimic dbapi() to prevent SADeprecationWarning

### DIFF
--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -59,6 +59,13 @@ class APSWDialect(SQLiteDialect):
         """
         return db
 
+    @classmethod
+    def import_dbapi(cls):  # pylint: disable=method-hidden
+        """
+        Return the DB API module.
+        """
+        return db
+
     def __init__(
         self,
         adapters: Optional[List[str]] = None,


### PR DESCRIPTION
- fix(backends\apsw\dialects\base.py): prevent SADeprecationWarning: Add import_dbapi() to mimic dbapi() to prevent SADeprecationWarning

# Summary
prevent SADeprecationWarning: Add import_dbapi() to mimic dbapi() to prevent SADeprecationWarning

# Testing instructions
What steps can be taken to manually verify the changes?

Install latest SQLAlchemy `pip install sqlalchemy` run the following code:

```Python
from sqlalchemy import create_engine, text

# Create the engine
engine = create_engine(
    "shillelagh://",
    adapters=["csvfile"]
)

# Connect to the engine
connection = engine.connect()

# Correct file path
csv_file_path = "C:/Users/<user_name>/adaptor_test/test.csv"
query = text(f"SELECT * FROM '{csv_file_path}'")

try:
    # Execute the query and fetch results
    result = connection.execute(query)

    # Print the results
    for row in result:
        print(row)
except Exception as e:
    print(f"Error: {e}")

```

and observe warning:
```
SADeprecationWarning: The dbapi() classmethod on dialect classes has been renamed to import_dbapi().  Implement an import_dbapi() classmethod directly on class <class 'shillelagh.backends.apsw.dialects.base.APSWDialect'> to remove this warning; the old .dbapi() classmethod may be maintained for backwards compatibility.
  engine = create_engine(
```


apply fix in PR and the warning is gone.