### PR TITLE
feat(generic JSON): handle array-only responses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Next
 ====
 
+- Handle array-only responses in the generic JSON adapter (#???)
+
 Version 1.2.21 - 2024-07-12
 ===========================
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ greenlet==2.0.2
     #   sqlalchemy
 idna==3.3
     # via requests
-packaging==23.0
+packaging==24.1
     # via shillelagh
 platformdirs==3.11.0
     # via requests-cache

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -105,7 +105,7 @@ numpy==1.23.1
     # via
     #   pandas
     #   pyarrow
-packaging==21.3
+packaging==24.1
     # via
     #   build
     #   pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     sqlalchemy>=1.3
     greenlet>=2.0.2  # needed for Python 3.11 w/o memory leak
     typing_extensions>=3.7.4.3
-    packaging
+    packaging>=24.1
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/shillelagh/adapters/api/generic_json.py
+++ b/src/shillelagh/adapters/api/generic_json.py
@@ -145,9 +145,14 @@ class GenericJSONAPI(Adapter):
             raise ProgrammingError(f'Error: {payload["error"]["message"]}')
 
         for i, row in enumerate(jsonpath.findall(self.path, payload)):
+            if isinstance(row, list):
+                row = {f"col_{i}": value for i, value in enumerate(row)}
+            elif row is None:
+                row = {}
+
             row = {
                 k: v
-                for k, v in (row or {}).items()
+                for k, v in row.items()
                 if requested_columns is None or k in requested_columns
             }
             row["rowid"] = i


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Handle array-only responses in the generic JSON adapter.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
