### PR TITLE
feat: upgrade lib from SQL

### DIFF
--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -459,7 +459,7 @@ def apsw_version() -> str:
     return f"{functions.version()} (apsw {apsw.apswversion()})"
 
 
-class Connection:
+class Connection:  # pylint: disable=too-many-instance-attributes
     """Connection."""
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -470,12 +470,14 @@ class Connection:
         isolation_level: Optional[str] = None,
         apsw_connection_kwargs: Optional[Dict[str, Any]] = None,
         schema: str = DEFAULT_SCHEMA,
+        safe: bool = False,
     ):
         # create underlying APSW connection
         apsw_connection_kwargs = apsw_connection_kwargs or {}
         self._connection = apsw.Connection(path, **apsw_connection_kwargs)
         self.isolation_level = isolation_level
         self.schema = schema
+        self.safe = safe
 
         # register adapters
         for adapter in adapters:
@@ -501,6 +503,9 @@ class Connection:
             ),
             "date_trunc": functions.date_trunc,
         }
+        if not safe:
+            available_functions["upgrade"] = functions.upgrade
+
         for name, function in available_functions.items():
             self._connection.create_scalar_function(name, function)
 
@@ -593,4 +598,5 @@ def connect(  # pylint: disable=too-many-arguments
         isolation_level,
         apsw_connection_kwargs,
         schema,
+        safe,
     )

--- a/src/shillelagh/functions.py
+++ b/src/shillelagh/functions.py
@@ -2,12 +2,17 @@
 Custom functions available to the SQL backend.
 """
 
+import importlib
 import json
 import sys
 import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Type
 
+import pip
+from packaging.version import InvalidVersion, Version
+
+import shillelagh
 from shillelagh.adapters.base import Adapter
 from shillelagh.fields import FastISODateTime
 from shillelagh.lib import find_adapter
@@ -17,7 +22,22 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import distribution
 
-__all__ = ["sleep", "get_metadata", "version"]
+__all__ = ["upgrade", "sleep", "get_metadata", "version", "date_trunc"]
+
+
+def upgrade(target_version: str) -> str:
+    """
+    Upgrade the library to a given version.
+    """
+    try:
+        pip.main(["install", f"shillelagh=={Version(target_version)}"])
+        importlib.reload(shillelagh)
+    except InvalidVersion:
+        return f"Invalid version: {target_version}"
+    except Exception as ex:  # pylint: disable=broad-except
+        return f"Upgrade failed: {ex}"
+
+    return f"Upgrade to {target_version} successful."
 
 
 def sleep(seconds: int) -> None:

--- a/tests/backends/apsw/db_test.py
+++ b/tests/backends/apsw/db_test.py
@@ -97,6 +97,7 @@ def test_connect_adapter_kwargs(mocker: MockerFixture, registry: AdapterLoader) 
         "IMMEDIATE",
         None,
         "main",
+        False,
     )
 
 
@@ -142,6 +143,7 @@ def test_connect_safe(mocker: MockerFixture, registry: AdapterLoader) -> None:
         None,
         None,
         "main",
+        False,
     )
 
     connect(":memory:", ["two"])
@@ -152,6 +154,7 @@ def test_connect_safe(mocker: MockerFixture, registry: AdapterLoader) -> None:
         None,
         None,
         "main",
+        False,
     )
 
     # in safe mode we need to specify adapters
@@ -163,6 +166,7 @@ def test_connect_safe(mocker: MockerFixture, registry: AdapterLoader) -> None:
         None,
         None,
         "main",
+        True,
     )
 
     # in safe mode only safe adapters are returned
@@ -174,6 +178,7 @@ def test_connect_safe(mocker: MockerFixture, registry: AdapterLoader) -> None:
         None,
         None,
         "main",
+        True,
     )
 
     # prevent repeated names, in case anyone registers a malicious adapter


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Allow upgrading Shillelagh from the process itself:

```sql
🍀> SELECT VERSION();
VERSION()
----------------------
1.2.25 (apsw 3.45.3.0)
(1 row in 0.00s)

🍀> SELECT UPGRADE("1.2.26");
UPGRADE("1.2.26")
-----------------------------
Upgrade to 1.2.26 successful.
(1 row in 0.76s)

🍀> SELECT VERSION();
VERSION()
----------------------
1.2.26 (apsw 3.45.3.0)
(1 row in 0.00s)

🍀>
```

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
