### PR TITLE
fix: Preset API pagination

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Next
 ====
 
+- Removes pagination from Preset API and adds note to documentation (#469)
+- Add ``UPGRADE()`` function to upgrade the library (#468)
+
 Version 1.2.26 - 2024-08-08
 ===========================
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -296,6 +296,8 @@ If an adapter declares support for ``LIMIT`` and ``OFFSET`` a corresponding para
 
 Now the adapter can handle ``limit`` and ``offset``, reducing the amount of data that is returned. Note that even if the adapter declares supporting ``LIMIT``, SQLite will still enforce the limit, ie, if for any reason the adapter returns more rows than the limit SQLite will fix the problem. The same is not true for the offset.
 
+Note that an adapter can only support ``limit`` and ``offset`` if it has filters on all the columns. Otherwise it would potentially return only a subset of the data, since after returning ``limit`` rows the data could be filtered further by SQLite.
+
 Returning only the requested columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/shillelagh/adapters/api/generic_json.py
+++ b/src/shillelagh/adapters/api/generic_json.py
@@ -134,8 +134,6 @@ class GenericJSONAPI(Adapter):
         self,
         bounds: Dict[str, Filter],
         order: List[Tuple[str, RequestedOrder]],
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
         requested_columns: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> Iterator[Row]:

--- a/src/shillelagh/adapters/api/generic_xml.py
+++ b/src/shillelagh/adapters/api/generic_xml.py
@@ -60,8 +60,6 @@ class GenericXMLAPI(GenericJSONAPI):
         self,
         bounds: Dict[str, Filter],
         order: List[Tuple[str, RequestedOrder]],
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
         requested_columns: Optional[Set[str]] = None,
         **kwargs: Any,
     ) -> Iterator[Row]:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fix the Preset API pagination, removing `limit` and `offset`.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
