### PR TITLE
feat: Duration field

### DIFF
--- a/src/shillelagh/fields.py
+++ b/src/shillelagh/fields.py
@@ -575,6 +575,15 @@ class StringDateTime(ISODateTime):
         return timestamp
 
 
+class Duration(Field[datetime.timedelta, datetime.timedelta]):
+    """
+    Shillelagh field used for representing durations as `timedelta` objects.
+    """
+
+    type = "DURATION"
+    db_api_type = "DATETIME"
+
+
 class StringDuration(Field[str, datetime.timedelta]):
     """
     A duration.

--- a/tests/fields_test.py
+++ b/tests/fields_test.py
@@ -383,6 +383,24 @@ def test_type_code() -> None:
     assert NUMBER != 1
 
 
+def test_duration() -> None:
+    """
+    Test ``Duration``.
+    """
+    connection = connect(":memory:")
+    cursor = connection.cursor()
+
+    sql = "CREATE TABLE test_table (a DURATION)"
+    cursor.execute(sql)
+
+    sql = "INSERT INTO test_table (a) VALUES (?)"
+    cursor.execute(sql, (datetime.timedelta(hours=1),))
+
+    sql = "SELECT * FROM test_table"
+    cursor.execute(sql)
+    assert cursor.fetchall() == [(datetime.timedelta(hours=1),)]
+
+
 def test_string_duration() -> None:
     """
     Test ``StringDuration``.


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

This is used by the Apache Superset Meta Database connector:

https://github.com/apache/superset/blob/0fdcd8b27e6d6ba70f8f38b4a033c61555af92bd/superset/extensions/metadb.py#L157-L163

Adding it here because it makes sense to exist here.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
