### PR TITLE
chore: bump apsw dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires =
     importlib-metadata; python_version<"3.10"
-    apsw>=3.9.2
+    apsw>=3.43.2.0
     python_dateutil>=2.8.1
     requests>=2.31.0
     requests-cache>=0.7.1


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Bump minimum apsw version to 3.43.2.0, when `createscalarfunction` [was renamed](https://rogerbinns.github.io/apsw/changes.html#renaming) to `create_scalar_function`.

Fixes https://github.com/betodealmeida/shillelagh/issues/487.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
