### PR TITLE
fix: NO_SUCH_TABLE regex

### DIFF
--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -83,7 +83,7 @@ sqlite_version_info = tuple(
     int(number) for number in apsw.sqlitelibversion().split(".")
 )
 
-NO_SUCH_TABLE = re.compile("(?:SQLError: )?no such table: (?P<uri>.*)")
+NO_SUCH_TABLE = re.compile("no such table: (?P<uri>.*)")
 DEFAULT_SCHEMA = "main"
 
 CURSOR_METHOD = TypeVar("CURSOR_METHOD", bound=Callable[..., Any])
@@ -250,7 +250,7 @@ class Cursor:  # pylint: disable=too-many-instance-attributes
                 break
             except apsw.SQLError as ex:
                 message = ex.args[0]
-                if match := NO_SUCH_TABLE.match(message):
+                if match := NO_SUCH_TABLE.search(message):
                     # create the virtual table
                     uri = match.groupdict()["uri"]
                     self._create_table(uri)

--- a/tests/backends/apsw/db_test.py
+++ b/tests/backends/apsw/db_test.py
@@ -13,7 +13,12 @@ import pytest
 from pytest_mock import MockerFixture
 
 from shillelagh.adapters.registry import AdapterLoader, UnsafeAdaptersError
-from shillelagh.backends.apsw.db import Connection, connect, convert_binding
+from shillelagh.backends.apsw.db import (
+    NO_SUCH_TABLE,
+    Connection,
+    connect,
+    convert_binding,
+)
 from shillelagh.exceptions import NotSupportedError, ProgrammingError
 from shillelagh.fields import Float, String, StringInteger
 
@@ -541,3 +546,19 @@ def test_best_index(mocker: MockerFixture) -> None:
         "some_adapter",
         VTModule(adapter),
     )
+
+
+@pytest.mark.parametrize(
+    "error,uri",
+    [
+        ("apsw.SQLError: no such table: dummy://", "dummy://"),
+        ("SQLError: no such table: dummy://", "dummy://"),
+        ("no such table: dummy://", "dummy://"),
+    ],
+)
+def test_no_such_table_search(error: str, uri: str) -> None:
+    """
+    Test ``NO_SUCH_TABLE`` search.
+    """
+    match = NO_SUCH_TABLE.search(error)
+    assert match and match.groupdict() == {"uri": uri}


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fixes https://github.com/betodealmeida/shillelagh/issues/494.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
