### PR TITLE
fix (gsheets): authenticated `get_table_names`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
 #    args: [--application-directories=.:src]
 
 - repo: https://github.com/hadialqattan/pycln
-  rev: v2.4.0
+  rev: v2.5.0
   hooks:
   - id: pycln
     args: [--config=pyproject.toml]

--- a/tests/backends/apsw/dialects/gsheets_test.py
+++ b/tests/backends/apsw/dialects/gsheets_test.py
@@ -488,3 +488,10 @@ def test_types_in_sqlalchemy(adapter_kwargs: dict[str, Any]) -> None:
             "test",
         ),
     ]
+
+
+def test_import_dbapi() -> None:
+    """
+    Test ``import_dbapi``.
+    """
+    assert APSWGSheetsDialect.import_dbapi() == APSWGSheetsDialect.dbapi()


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Fix how we build the credentials when calling `get_table_names` for the GSheets dialect.

Also fixes https://github.com/betodealmeida/shillelagh/issues/505.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
