### PR TITLE
fix: use only usable constraints

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,3 +8,6 @@ disable =
 
 [TYPECHECK]
 ignored-modules=apsw
+
+[DESIGN]
+max-positional-arguments=6

--- a/src/shillelagh/backends/apsw/vt.py
+++ b/src/shillelagh/backends/apsw/vt.py
@@ -419,6 +419,7 @@ class VTTable:
         constraints = [
             (constraint.get("iColumn", -1), constraint["op"])
             for constraint in index_info_dict["aConstraint"]
+            if constraint["usable"]
         ]
         orderbys = [
             (orderby["iColumn"], orderby["desc"])

--- a/tests/backends/apsw/vt_test.py
+++ b/tests/backends/apsw/vt_test.py
@@ -121,10 +121,11 @@ def test_virtual_best_index_object(mocker: MockerFixture) -> None:
     index_info_to_dict = mocker.patch("shillelagh.backends.apsw.vt.index_info_to_dict")
     index_info_to_dict.return_value = {
         "aConstraint": [
-            {"iColumn": 1, "op": apsw.SQLITE_INDEX_CONSTRAINT_EQ},
-            {"iColumn": 2, "op": apsw.SQLITE_INDEX_CONSTRAINT_GT},
-            {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_LE},
-            {"op": 73},
+            {"iColumn": 1, "op": apsw.SQLITE_INDEX_CONSTRAINT_EQ, "usable": True},
+            {"iColumn": 2, "op": apsw.SQLITE_INDEX_CONSTRAINT_GT, "usable": True},
+            {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_LE, "usable": True},
+            {"iColumn": 0, "op": apsw.SQLITE_INDEX_CONSTRAINT_GT, "usable": False},
+            {"op": 73, "usable": True},
         ],
         "aOrderBy": [{"iColumn": 1, "desc": False}],
         "colUsed_names": ["age", "pets"],


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Change `BestIndexObject` to only use usable constraints.

Fixes https://github.com/betodealmeida/shillelagh/issues/520.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
