### PR TITLE
feat: simple MetricFlow adapter+dialect for Superset

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -193,6 +193,7 @@ sqlalchemy.dialects =
     shillelagh.apsw = shillelagh.backends.apsw.dialects.base:APSWDialect
     shillelagh.safe = shillelagh.backends.apsw.dialects.safe:APSWSafeDialect
     gsheets = shillelagh.backends.apsw.dialects.gsheets:APSWGSheetsDialect
+    metricflow = shillelagh.backends.apsw.dialects.metricflow:MetricFlowDialect
     shillelagh.multicorn2 = shillelagh.backends.multicorn.dialects.base:Multicorn2Dialect
     shillelagh.sqlglot = shillelagh.backends.sqlglot.dialects.base:SQLGlotDialect
 console_scripts =

--- a/src/shillelagh/adapters/api/dbt_metricflow.py
+++ b/src/shillelagh/adapters/api/dbt_metricflow.py
@@ -390,7 +390,9 @@ class DbtMetricFlowAPI(Adapter):
             },
         )
 
-        return {metric["name"] for metric in payload["data"]["metricsForDimensions"]}
+        return {
+            metric["name"] for metric in payload["data"].get("metricsForDimensions", [])
+        }
 
     def _get_dimensions_for_metrics(self, metrics: set[str]) -> set[str]:
         """
@@ -411,12 +413,9 @@ class DbtMetricFlowAPI(Adapter):
         ) in self.grains.items():
             reverse_grain[name].add(alias)
 
-        dimensions: set[str] = set()
-        for dimension in payload["data"]["dimensions"]:
-            if dimension["name"] in self.dimensions:
-                dimensions.add(dimension["name"])
-            elif dimension["name"] in reverse_grain:
-                dimensions.update(reverse_grain[dimension["name"]])
+        dimensions = {"metric_time"}
+        for dimension in payload["data"].get("dimensions", []):
+            dimensions.add(dimension["name"])
 
         return dimensions
 

--- a/src/shillelagh/adapters/api/dbt_metricflow.py
+++ b/src/shillelagh/adapters/api/dbt_metricflow.py
@@ -29,6 +29,7 @@ import re
 import time
 from collections import defaultdict
 from collections.abc import Iterator
+from functools import lru_cache
 from typing import Any, Optional, TypedDict, cast
 from urllib.parse import urlparse
 
@@ -312,6 +313,7 @@ class DbtMetricFlowAPI(Adapter):
 
         return "https://semantic-layer.cloud.getdbt.com/api/graphql"
 
+    @lru_cache(maxsize=1)
     def _set_columns(self) -> None:
         payload = self.client.execute(
             query=LIST_METRICS,

--- a/src/shillelagh/backends/apsw/dialects/base.py
+++ b/src/shillelagh/backends/apsw/dialects/base.py
@@ -20,7 +20,16 @@ from shillelagh.exceptions import ProgrammingError
 from shillelagh.lib import find_adapter
 
 
-class SQLAlchemyColumn(TypedDict):
+class ComputedColumn(TypedDict):
+    """
+    A custom type for a computed column in SQLAlchemy.
+    """
+
+    sqltext: str
+    persisted: bool
+
+
+class SQLAlchemyColumn(TypedDict, total=False):
     """
     A custom type for a SQLAlchemy column.
     """
@@ -31,6 +40,8 @@ class SQLAlchemyColumn(TypedDict):
     default: Optional[str]
     autoincrement: str
     primary_key: int
+    comment: Optional[str]
+    computed: Optional[ComputedColumn]
 
 
 class APSWDialect(SQLiteDialect):

--- a/src/shillelagh/backends/apsw/dialects/metricflow.py
+++ b/src/shillelagh/backends/apsw/dialects/metricflow.py
@@ -1,0 +1,241 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=unused-argument, abstract-method
+
+"""
+A SQLAlchemy dialect for dbt Metric Flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import sqlalchemy.types
+from sqlalchemy.engine.base import Connection
+from sqlalchemy.engine.url import URL
+from sqlalchemy.sql.type_api import TypeEngine
+
+from shillelagh.adapters.api.dbt_metricflow import DbtMetricFlowAPI
+from shillelagh.adapters.registry import registry
+from shillelagh.backends.apsw.dialects.base import (
+    APSWDialect,
+    SQLAlchemyColumn,
+    get_adapter_for_table_name,
+)
+from shillelagh.fields import Field
+
+TABLE_NAME = "metrics"
+
+
+def get_sqla_type(field: Field) -> type[TypeEngine]:
+    """
+    Convert from Shillelagh to SQLAlchemy types.
+    """
+    type_map: dict[str, type[TypeEngine]] = {
+        "BOOLEAN": sqlalchemy.types.BOOLEAN,
+        "INTEGER": sqlalchemy.types.INT,
+        "DECIMAL": sqlalchemy.types.DECIMAL,
+        "TIMESTAMP": sqlalchemy.types.TIMESTAMP,
+        "DATE": sqlalchemy.types.DATE,
+        "TIME": sqlalchemy.types.TIME,
+        "TEXT": sqlalchemy.types.TEXT,
+    }
+
+    return type_map.get(field.type, sqlalchemy.types.TEXT)
+
+
+class TableMetricFlowAPI(DbtMetricFlowAPI):
+    """
+    Custom API adapter for dbt Metric Flow API.
+
+    In the original adapter, the SQL queries a base dbt API URL, eg:
+
+        SELECT * FROM "https://semantic-layer.cloud.getdbt.com/";
+        SELECT * FROM "https://ab123.us1.dbt.com/";  -- custom user URL
+
+    For this adapter, we want a leaner URI, mimicking a table:
+
+        SELECT * FROM metrics;
+
+    In order to do this, we override the ``supports`` method to only accept
+    ``$TABLE_NAME`` instead of the URL, which is then passed to the adapter when it is
+    instantiated.
+    """
+
+    @staticmethod
+    def supports(uri: str, fast: bool = True, **kwargs: Any) -> bool:
+        return uri == TABLE_NAME
+
+    def __init__(
+        self,
+        table: str,
+        service_token: str,
+        environment_id: int,
+        url: str,
+    ) -> None:
+        # pass URL as the table name to the base class, since that's the actual URL
+        super().__init__(url, service_token, environment_id)
+
+        # but make sure we set the table name to the expected one, since `get_data`
+        # needs it
+        self.table = table
+
+
+class MetricFlowDialect(APSWDialect):
+    """
+    A dbt Metric Flow dialect.
+
+    URL should look like:
+
+        metricflow:///<environment_id>?service_token=<service_token>
+
+    Or when using a custom URL:
+
+        metricflow://ab123.us1.dbt.com/<environment_id>?service_token=<service_token>
+
+    """
+
+    name = "metricflow"
+
+    supports_statement_cache = True
+
+    def create_connect_args(self, url: URL) -> tuple[tuple[()], dict[str, Any]]:
+        baseurl = (
+            f"https://{url.host}/"
+            if url.host
+            else "https://semantic-layer.cloud.getdbt.com/"
+        )
+
+        if "tablemetricflowapi" not in registry.loaders:
+            registry.add("tablemetricflowapi", TableMetricFlowAPI)
+
+        return (
+            (),
+            {
+                "path": ":memory:",
+                "adapters": ["tablemetricflowapi"],
+                "adapter_kwargs": {
+                    "tablemetricflowapi": {
+                        "service_token": url.query["service_token"],
+                        "environment_id": int(url.database),
+                        "url": baseurl,
+                    },
+                },
+                "safe": True,
+                "isolation_level": self.isolation_level,
+            },
+        )
+
+    def get_table_names(
+        self,
+        connection: Connection,
+        schema: str | None = None,
+        sqlite_include_internal: bool = False,
+        **kwargs: Any,
+    ) -> list[str]:
+        return [TABLE_NAME]
+
+    def has_table(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: str | None = None,
+        **kwargs: Any,
+    ) -> bool:
+        return table_name == TABLE_NAME
+
+    def get_columns(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: str | None = None,
+        **kwargs: Any,
+    ) -> list[SQLAlchemyColumn]:
+        columns: list[SQLAlchemyColumn] = []
+        adapter = cast(
+            DbtMetricFlowAPI,
+            get_adapter_for_table_name(connection, table_name),
+        )
+
+        dimensions = {
+            (
+                adapter.grains[dimension][0]
+                if dimension in adapter.grains
+                else dimension
+            ): adapter.columns[dimension]
+            for dimension in adapter.dimensions
+        }
+        for name, field in dimensions.items():
+            columns.append(
+                {
+                    "name": name,
+                    "type": get_sqla_type(field),
+                    "nullable": True,
+                    "default": None,
+                    "comment": adapter.dimensions.get(name, ""),
+                },
+            )
+
+        metrics = {metric: adapter.columns[metric] for metric in adapter.metrics}
+        for name, field in metrics.items():
+            columns.append(
+                {
+                    "name": name,
+                    "type": get_sqla_type(field),
+                    "nullable": True,
+                    "default": None,
+                    "comment": adapter.metrics.get(name, ""),
+                    "computed": {"sqltext": name, "persisted": True},
+                },
+            )
+
+        return columns
+
+    def get_schema_names(
+        self,
+        connection: Connection,
+        **kwargs: Any,
+    ) -> list[str]:
+        return ["main"]
+
+    def get_pk_constraint(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return {"constrained_columns": [], "name": None}
+
+    def get_foreign_keys(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: str | None = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return []
+
+    get_check_constraints = get_foreign_keys
+    get_indexes = get_foreign_keys
+    get_unique_constraints = get_foreign_keys
+
+    def get_table_comment(self, connection, table_name, schema=None, **kwargs):
+        return {
+            "text": "A virtual table that gives access to all dbt metrics & dimensions.",
+        }

--- a/tests/adapters/api/dbt_metricflow_test.py
+++ b/tests/adapters/api/dbt_metricflow_test.py
@@ -1098,10 +1098,15 @@ def test_get_dimensions_for_metrics(mocker: MockerFixture) -> None:
     }
 
     assert adapter._get_dimensions_for_metrics({"orders"}) == {
+        "customer__customer_name",
+        "customer__customer_type",
+        "customer__first_ordered_at",
+        "customer__last_ordered_at",
+        "location__location_name",
+        "location__opened_at",
+        "metric_time",
+        "order_id__is_drink_order",
         "order_id__is_food_order",
-        "metric_time__day",
-        "metric_time__week",
-        "metric_time__month",
-        "metric_time__year",
-        "metric_time__quarter",
+        "order_id__order_total_dim",
+        "order_id__ordered_at",
     }

--- a/tests/backends/apsw/dialects/metricflow_test.py
+++ b/tests/backends/apsw/dialects/metricflow_test.py
@@ -1,0 +1,357 @@
+"""
+Tests for shillelagh.backends.apsw.dialects.metricflow.
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import sqlalchemy
+from sqlalchemy.engine.url import make_url
+
+from shillelagh.backends.apsw.dialects.metricflow import (
+    MetricFlowDialect,
+    TableMetricFlowAPI,
+    get_sqla_type,
+)
+from shillelagh.fields import Boolean, DateTime, Decimal, Integer, String
+
+
+def test_get_sqla_type() -> None:
+    """
+    Test ``get_sqla_type`` function.
+    """
+    # Test all supported field types
+    field_boolean = Boolean()
+    assert get_sqla_type(field_boolean) == sqlalchemy.types.BOOLEAN
+
+    field_integer = Integer()
+    assert get_sqla_type(field_integer) == sqlalchemy.types.INT
+
+    field_decimal = Decimal()
+    assert get_sqla_type(field_decimal) == sqlalchemy.types.DECIMAL
+
+    field_timestamp = DateTime()
+    assert get_sqla_type(field_timestamp) == sqlalchemy.types.TIMESTAMP
+
+    # Create a field with DATE type by mocking
+    field_date = Integer()  # Use as base
+    field_date.type = "DATE"
+    assert get_sqla_type(field_date) == sqlalchemy.types.DATE
+
+    # Create a field with TIME type by mocking
+    field_time = Integer()  # Use as base
+    field_time.type = "TIME"
+    assert get_sqla_type(field_time) == sqlalchemy.types.TIME
+
+    field_text = String()
+    assert get_sqla_type(field_text) == sqlalchemy.types.TEXT
+
+    # Test unknown type defaults to TEXT
+    field_unknown = Integer()  # Use as base
+    field_unknown.type = "UNKNOWN"
+    assert get_sqla_type(field_unknown) == sqlalchemy.types.TEXT
+
+
+def test_table_metricflow_api_supports() -> None:
+    """
+    Test ``TableMetricFlowAPI.supports`` method.
+    """
+    # Should support only "metrics" table
+    assert TableMetricFlowAPI.supports("metrics") is True
+    assert TableMetricFlowAPI.supports("other_table") is False
+    assert TableMetricFlowAPI.supports("https://example.com") is False
+
+
+def test_table_metricflow_api_init() -> None:
+    """
+    Test ``TableMetricFlowAPI`` initialization.
+    """
+    with mock.patch(
+        "shillelagh.backends.apsw.dialects.metricflow.DbtMetricFlowAPI.__init__",
+    ) as mock_super_init:
+        mock_super_init.return_value = None
+
+        api = TableMetricFlowAPI(
+            table="metrics",
+            service_token="test_token",
+            environment_id=123,
+            url="https://example.com/",
+        )
+
+        # Should call super().__init__ with URL as the table name
+        mock_super_init.assert_called_once_with(
+            "https://example.com/",
+            "test_token",
+            123,
+        )
+
+        # Should set table attribute correctly
+        assert api.table == "metrics"
+
+
+def test_metricflow_dialect_name() -> None:
+    """
+    Test ``MetricFlowDialect`` name attribute.
+    """
+    dialect = MetricFlowDialect()
+    assert dialect.name == "metricflow"
+
+
+def test_metricflow_dialect_supports_statement_cache() -> None:
+    """
+    Test ``MetricFlowDialect`` supports_statement_cache attribute.
+    """
+    dialect = MetricFlowDialect()
+    assert dialect.supports_statement_cache is True
+
+
+def test_metricflow_dialect_create_connect_args_default_host() -> None:
+    """
+    Test ``MetricFlowDialect.create_connect_args`` with default host.
+    """
+    dialect = MetricFlowDialect()
+    url = make_url("metricflow:///123?service_token=test_token")
+
+    with mock.patch(
+        "shillelagh.backends.apsw.dialects.metricflow.registry",
+    ) as mock_registry:
+        mock_registry.loaders = {}
+
+        args, kwargs = dialect.create_connect_args(url)
+
+        assert args == ()
+        assert kwargs == {
+            "path": ":memory:",
+            "adapters": ["tablemetricflowapi"],
+            "adapter_kwargs": {
+                "tablemetricflowapi": {
+                    "service_token": "test_token",
+                    "environment_id": 123,
+                    "url": "https://semantic-layer.cloud.getdbt.com/",
+                },
+            },
+            "safe": True,
+            "isolation_level": None,
+        }
+
+        # Should register the adapter
+        mock_registry.add.assert_called_once_with(
+            "tablemetricflowapi",
+            TableMetricFlowAPI,
+        )
+
+
+def test_metricflow_dialect_create_connect_args_custom_host() -> None:
+    """
+    Test ``MetricFlowDialect.create_connect_args`` with custom host.
+    """
+    dialect = MetricFlowDialect()
+    url = make_url("metricflow://custom.example.com/123?service_token=test_token")
+
+    with mock.patch(
+        "shillelagh.backends.apsw.dialects.metricflow.registry",
+    ) as mock_registry:
+        mock_registry.loaders = {}
+
+        args, kwargs = dialect.create_connect_args(url)
+
+        assert args == ()
+        assert kwargs == {
+            "path": ":memory:",
+            "adapters": ["tablemetricflowapi"],
+            "adapter_kwargs": {
+                "tablemetricflowapi": {
+                    "service_token": "test_token",
+                    "environment_id": 123,
+                    "url": "https://custom.example.com/",
+                },
+            },
+            "safe": True,
+            "isolation_level": None,
+        }
+
+
+def test_metricflow_dialect_create_connect_args_adapter_already_registered() -> None:
+    """
+    Test ``MetricFlowDialect.create_connect_args`` when adapter is already registered.
+    """
+    dialect = MetricFlowDialect()
+    url = make_url("metricflow:///123?service_token=test_token")
+
+    with mock.patch(
+        "shillelagh.backends.apsw.dialects.metricflow.registry",
+    ) as mock_registry:
+        mock_registry.loaders = {"tablemetricflowapi": "already_registered"}
+
+        dialect.create_connect_args(url)
+
+        # Should not call add when already registered
+        mock_registry.add.assert_not_called()
+
+
+def test_metricflow_dialect_get_table_names() -> None:
+    """
+    Test ``MetricFlowDialect.get_table_names`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    result = dialect.get_table_names(mock_connection)
+    assert result == ["metrics"]
+
+    # Test with different parameters
+    result = dialect.get_table_names(mock_connection, schema="test_schema")
+    assert result == ["metrics"]
+
+    result = dialect.get_table_names(mock_connection, sqlite_include_internal=True)
+    assert result == ["metrics"]
+
+
+def test_metricflow_dialect_has_table() -> None:
+    """
+    Test ``MetricFlowDialect.has_table`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    assert dialect.has_table(mock_connection, "metrics") is True
+    assert dialect.has_table(mock_connection, "other_table") is False
+
+    # Test with schema parameter
+    assert dialect.has_table(mock_connection, "metrics", schema="test_schema") is True
+    assert (
+        dialect.has_table(mock_connection, "other_table", schema="test_schema") is False
+    )
+
+
+def test_metricflow_dialect_get_columns() -> None:
+    """
+    Test ``MetricFlowDialect.get_columns`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    # Create mock adapter
+    mock_adapter = MagicMock()
+    mock_adapter.dimensions = {"dim1": "Dimension 1", "dim2": "Dimension 2"}
+    mock_adapter.grains = {"dim1": ["grain1"]}
+    mock_adapter.metrics = {"metric1": "Metric 1", "metric2": "Metric 2"}
+    mock_adapter.columns = {
+        "dim1": String(),
+        "dim2": Integer(),
+        "metric1": Decimal(),
+        "metric2": DateTime(),
+    }
+
+    with mock.patch(
+        "shillelagh.backends.apsw.dialects.metricflow.get_adapter_for_table_name",
+    ) as mock_get_adapter:
+        mock_get_adapter.return_value = mock_adapter
+
+        result = dialect.get_columns(mock_connection, "metrics")
+
+        expected = [
+            {
+                "name": "grain1",
+                "type": sqlalchemy.types.TEXT,
+                "nullable": True,
+                "default": None,
+                "comment": "",
+            },
+            {
+                "name": "dim2",
+                "type": sqlalchemy.types.INT,
+                "nullable": True,
+                "default": None,
+                "comment": "Dimension 2",
+            },
+            {
+                "name": "metric1",
+                "type": sqlalchemy.types.DECIMAL,
+                "nullable": True,
+                "default": None,
+                "comment": "Metric 1",
+                "computed": {"sqltext": "metric1", "persisted": True},
+            },
+            {
+                "name": "metric2",
+                "type": sqlalchemy.types.TIMESTAMP,
+                "nullable": True,
+                "default": None,
+                "comment": "Metric 2",
+                "computed": {"sqltext": "metric2", "persisted": True},
+            },
+        ]
+
+        assert result == expected
+
+
+def test_metricflow_dialect_get_schema_names() -> None:
+    """
+    Test ``MetricFlowDialect.get_schema_names`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    result = dialect.get_schema_names(mock_connection)
+    assert result == ["main"]
+
+
+def test_metricflow_dialect_get_pk_constraint() -> None:
+    """
+    Test ``MetricFlowDialect.get_pk_constraint`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    result = dialect.get_pk_constraint(mock_connection, "metrics")
+    assert result == {"constrained_columns": [], "name": None}
+
+    # Test with schema parameter
+    result = dialect.get_pk_constraint(mock_connection, "metrics", schema="test_schema")
+    assert result == {"constrained_columns": [], "name": None}
+
+
+def test_metricflow_dialect_get_foreign_keys() -> None:
+    """
+    Test ``MetricFlowDialect.get_foreign_keys`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    result = dialect.get_foreign_keys(mock_connection, "metrics")
+    assert result == []
+
+    # Test with schema parameter
+    result = dialect.get_foreign_keys(mock_connection, "metrics", schema="test_schema")
+    assert result == []
+
+
+def test_metricflow_dialect_constraint_methods() -> None:
+    """
+    Test that constraint methods are properly aliased.
+    """
+    dialect = MetricFlowDialect()
+
+    # These methods should be aliases to get_foreign_keys
+    assert dialect.get_check_constraints == dialect.get_foreign_keys
+    assert dialect.get_indexes == dialect.get_foreign_keys
+    assert dialect.get_unique_constraints == dialect.get_foreign_keys
+
+
+def test_metricflow_dialect_get_table_comment() -> None:
+    """
+    Test ``MetricFlowDialect.get_table_comment`` method.
+    """
+    dialect = MetricFlowDialect()
+    mock_connection = MagicMock()
+
+    result = dialect.get_table_comment(mock_connection, "metrics")
+    expected = {
+        "text": "A virtual table that gives access to all dbt metrics & dimensions.",
+    }
+    assert result == expected
+
+    # Test with schema parameter
+    result = dialect.get_table_comment(mock_connection, "metrics", schema="test_schema")
+    assert result == expected


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Add a SQLAlchemy dialect for MetricFlow, so it can be used with Apache Superset.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
