### PR TITLE
docs: add sqlalchemy-odata to 3rd-party adapters list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ There are also 3rd-party adapters:
 
 - `Airtable <https://github.com/cancan101/airtable-db-api>`_
 - `GraphQL <https://github.com/cancan101/graphql-db-api>`_
+- `OData v4 <https://github.com/brandonjjon/sqlalchemy-odata>`_
 
 A query can combine data from multiple adapters:
 


### PR DESCRIPTION
# Summary

Adds [sqlalchemy-odata](https://github.com/brandonjjon/sqlalchemy-odata) to the 3rd-party adapters list in the README.                                                           

It's a Shillelagh adapter and SQLAlchemy dialect for OData v4 APIs — auto-discovers entity sets from `$metadata`, fetches data via pagination, and includes a Superset engine spec. Available on [PyPI](https://pypi.org/project/sqlalchemy-odata/).

# Testing instructions

README-only change — no code to test.