### PR TITLE
fix: improve date parsing error messages with value and pattern context

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/exceptions.py
+++ b/src/shillelagh/adapters/api/gsheets/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Exceptions specific to the Google Sheets adapter.
+"""
+
+from shillelagh.exceptions import Error
+
+
+class DateParseError(Error):
+    """
+    Raised when a date/time value cannot be parsed from a given pattern.
+    """

--- a/src/shillelagh/adapters/api/gsheets/parsing/date.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/date.py
@@ -14,7 +14,7 @@ from enum import Enum
 from typing import Any, TypeVar, Union
 
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token, tokenize
-from shillelagh.exceptions import DateParseError
+from shillelagh.exceptions import DateParseError, ProgrammingError
 
 DateTime = TypeVar("DateTime", datetime, date, time, timedelta)
 
@@ -103,7 +103,7 @@ class M(Token):
             if token is self:
                 break
         else:
-            raise Exception("Token is not present in list of tokens")
+            raise ProgrammingError("Token is not present in list of tokens")
 
         for token in reversed(tokens[:i]):
             if token.__class__.__name__ == "LITERAL":
@@ -128,7 +128,7 @@ class M(Token):
         if isinstance(value, (datetime, date)):
             return str(value.month)
 
-        raise Exception(f"Cannot format value: {value}")
+        raise ProgrammingError(f"Cannot format value: {value}")
 
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d{1,2}", value)
@@ -208,7 +208,9 @@ class MMMMM(MMM):
         if len(mapping[letter]) == 0:
             raise DateParseError(f"Unable to find month letter: {letter}")
         if len(mapping[letter]) > 1:
-            raise DateParseError(f"Unable to parse month letter unambiguously: {letter}")
+            raise DateParseError(
+                f"Unable to parse month letter unambiguously: {letter}",
+            )
 
         return {"month": mapping[letter][0]}, value[1:]
 
@@ -646,7 +648,7 @@ def parse_date_time_pattern(
         return class_(**kwargs)
     except TypeError as ex:
         raise DateParseError(
-            f"Could not parse '{value}' using pattern '{pattern}': {ex}"
+            f"Could not parse '{value}' using pattern '{pattern}': {ex}",
         ) from ex
 
 

--- a/src/shillelagh/adapters/api/gsheets/parsing/date.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/date.py
@@ -13,8 +13,9 @@ from datetime import date, datetime, time, timedelta
 from enum import Enum
 from typing import Any, TypeVar, Union
 
+from shillelagh.adapters.api.gsheets.exceptions import DateParseError
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token, tokenize
-from shillelagh.exceptions import DateParseError, ProgrammingError
+from shillelagh.exceptions import ProgrammingError
 
 DateTime = TypeVar("DateTime", datetime, date, time, timedelta)
 

--- a/src/shillelagh/adapters/api/gsheets/parsing/date.py
+++ b/src/shillelagh/adapters/api/gsheets/parsing/date.py
@@ -4,7 +4,7 @@ Parse and format Google Sheet date/time patterns.
 https://developers.google.com/sheets/api/guides/formats?hl=en#date_and_time_format_patterns
 """
 
-# pylint: disable=invalid-name, fixme, broad-exception-raised
+# pylint: disable=invalid-name, fixme
 
 import calendar
 import re
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Any, TypeVar, Union
 
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token, tokenize
+from shillelagh.exceptions import DateParseError
 
 DateTime = TypeVar("DateTime", datetime, date, time, timedelta)
 
@@ -63,7 +64,7 @@ class H(Token):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d{1,2}", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group()) if 0 <= int(match.group()) < 24 else 1
 
         return {"hour": int(value[:size])}, value[size:]
@@ -132,7 +133,7 @@ class M(Token):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d{1,2}", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group()) if 1 <= int(match.group()) <= 24 else 1
 
         if self._is_minute(tokens):
@@ -205,9 +206,9 @@ class MMMMM(MMM):
         for i in range(1, 13):
             mapping[calendar.month_name[i][0]].append(i)
         if len(mapping[letter]) == 0:
-            raise Exception(f"Unable to find month letter: {letter}")
+            raise DateParseError(f"Unable to find month letter: {letter}")
         if len(mapping[letter]) > 1:
-            raise Exception(f"Unable to parse month letter unambiguously: {letter}")
+            raise DateParseError(f"Unable to parse month letter unambiguously: {letter}")
 
         return {"month": mapping[letter][0]}, value[1:]
 
@@ -225,7 +226,7 @@ class S(Token):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d{1,2}", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         # leap seconds can be 60 or even 61
         size = len(match.group()) if 0 <= int(match.group()) <= 61 else 1
 
@@ -313,7 +314,7 @@ class HPlusDuration(DurationToken):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d+", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group())
         return {"hours": int(value[:size])}, value[size:]
 
@@ -338,7 +339,7 @@ class MPlusDuration(DurationToken):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d+", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group())
         return {"minutes": int(value[:size])}, value[size:]
 
@@ -367,7 +368,7 @@ class SPlusDuration(DurationToken):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d+", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group())
         return {"seconds": int(value[:size])}, value[size:]
 
@@ -385,7 +386,7 @@ class D(Token):
     def parse(self, value: str, tokens: list[Token]) -> tuple[dict[str, Any], str]:
         match = re.match(r"\d{1,2}", value)
         if not match:
-            raise Exception(f"Cannot parse value: {value}")
+            raise DateParseError(f"Cannot parse value: {value}")
         size = len(match.group()) if 1 <= int(match.group()) <= 31 else 1
         return {"day": int(value[:size])}, value[size:]
 
@@ -644,7 +645,9 @@ def parse_date_time_pattern(
     try:
         return class_(**kwargs)
     except TypeError as ex:
-        raise Exception("Unsupported format") from ex
+        raise DateParseError(
+            f"Could not parse '{value}' using pattern '{pattern}': {ex}"
+        ) from ex
 
 
 def format_date_time_pattern(value: DateTime, pattern: str) -> str:

--- a/src/shillelagh/exceptions.py
+++ b/src/shillelagh/exceptions.py
@@ -13,7 +13,6 @@ __all__ = [
     "InternalError",
     "ProgrammingError",
     "NotSupportedError",
-    "DateParseError",
 ]
 
 
@@ -131,10 +130,4 @@ class ImpossibleFilterError(Error):
 class UnauthenticatedError(InterfaceError):
     """
     Custom excepton raised when the user needs to authenticate.
-    """
-
-
-class DateParseError(Error):
-    """
-    Raised when a date/time value cannot be parsed from a given pattern.
     """

--- a/src/shillelagh/exceptions.py
+++ b/src/shillelagh/exceptions.py
@@ -13,6 +13,7 @@ __all__ = [
     "InternalError",
     "ProgrammingError",
     "NotSupportedError",
+    "DateParseError",
 ]
 
 
@@ -130,4 +131,10 @@ class ImpossibleFilterError(Error):
 class UnauthenticatedError(InterfaceError):
     """
     Custom excepton raised when the user needs to authenticate.
+    """
+
+
+class DateParseError(Error):
+    """
+    Raised when a date/time value cannot be parsed from a given pattern.
     """

--- a/tests/adapters/api/gsheets/parsing/date_test.py
+++ b/tests/adapters/api/gsheets/parsing/date_test.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 
+from shillelagh.adapters.api.gsheets.exceptions import DateParseError
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token
 from shillelagh.adapters.api.gsheets.parsing.date import (
     AMPM,
@@ -37,7 +38,7 @@ from shillelagh.adapters.api.gsheets.parsing.date import (
     parse_date_time_pattern,
     tokenize,
 )
-from shillelagh.exceptions import DateParseError, ProgrammingError
+from shillelagh.exceptions import ProgrammingError
 
 classes = [
     H,

--- a/tests/adapters/api/gsheets/parsing/date_test.py
+++ b/tests/adapters/api/gsheets/parsing/date_test.py
@@ -9,6 +9,7 @@ from typing import cast
 import pytest
 
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token
+from shillelagh.exceptions import DateParseError
 from shillelagh.adapters.api.gsheets.parsing.date import (
     AMPM,
     AP,
@@ -150,7 +151,7 @@ def test_h_token() -> None:
     tokens = list(tokenize("h:mm:ss", classes))
     assert token.parse("123", tokens) == ({"hour": 12}, "3")
     assert token.parse("303", tokens) == ({"hour": 3}, "03")
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", tokens)
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -220,7 +221,7 @@ def test_m_token() -> None:
     tokens = list(tokenize("h:m:s", classes))
     token = tokens[2]
     assert token.parse("14:15", tokens) == ({"minute": 14}, ":15")
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", tokens)
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -288,10 +289,10 @@ def test_mmmmm_token() -> None:
     tokens = list(tokenize("mmmmm/dd/yyy", classes))
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "N"
     assert token.parse("F 1st", tokens) == ({"month": 2}, " 1st")
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("Z 1st", tokens)
     assert str(excinfo.value) == "Unable to find month letter: Z"
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("M 1st", tokens)
     assert str(excinfo.value) == "Unable to parse month letter unambiguously: M"
 
@@ -315,7 +316,7 @@ def test_s_token() -> None:
     assert token.parse("60.123", tokens) == ({"second": 60}, ".123")
     assert token.parse("61.123", tokens) == ({"second": 61}, ".123")
     assert token.parse("62.123", tokens) == ({"second": 6}, "2.123")
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", tokens)
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -370,7 +371,7 @@ def test_hplusduration_token() -> None:
     )
 
     # should never happen
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", [])
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -414,7 +415,7 @@ def test_mplusduration_token() -> None:
     )
 
     # should never happen
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", [])
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -461,7 +462,7 @@ def test_splusduration_token() -> None:
     )
 
     # should never happen
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", [])
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -481,7 +482,7 @@ def test_d_token() -> None:
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "12"
     assert token.format(datetime(2021, 11, 2, 13, 14, 15, 16), tokens) == "2"
     assert token.parse("12/11/21", tokens) == ({"day": 12}, "/11/21")
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         token.parse("invalid", tokens)
     assert str(excinfo.value) == "Cannot parse value: invalid"
 
@@ -672,9 +673,10 @@ def test_parse_date_time_pattern() -> None:
         microseconds=123000,
     )
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(DateParseError) as excinfo:
         parse_date_time_pattern("60.123", "[ss].000", datetime)
-    assert str(excinfo.value) == "Unsupported format"
+    assert "Could not parse" in str(excinfo.value)
+    assert "[ss].000" in str(excinfo.value)
 
 
 def test_format_date_time_pattern() -> None:
@@ -744,6 +746,19 @@ def test_format_date_time_with_meridiem() -> None:
         )
         == "12:34:56 PM"
     )
+
+
+def test_parse_date_time_pattern_missing_day() -> None:
+    """
+    Test that a pattern without a day component gives a helpful error message.
+
+    This is the case when a Google Sheet has a date column with M/YYYY format
+    (e.g. "1/2024") instead of M/D/YYYY (e.g. "1/1/2024").
+    """
+    with pytest.raises(DateParseError, match="Could not parse") as excinfo:
+        parse_date_time_pattern("1/2024", "m/yyyy", date)
+    assert "1/2024" in str(excinfo.value) or "m/yyyy" in str(excinfo.value)
+    assert "m/yyyy" in str(excinfo.value)
 
 
 def test_infer_column_type() -> None:

--- a/tests/adapters/api/gsheets/parsing/date_test.py
+++ b/tests/adapters/api/gsheets/parsing/date_test.py
@@ -9,7 +9,6 @@ from typing import cast
 import pytest
 
 from shillelagh.adapters.api.gsheets.parsing.base import LITERAL, Token
-from shillelagh.exceptions import DateParseError
 from shillelagh.adapters.api.gsheets.parsing.date import (
     AMPM,
     AP,
@@ -38,6 +37,7 @@ from shillelagh.adapters.api.gsheets.parsing.date import (
     parse_date_time_pattern,
     tokenize,
 )
+from shillelagh.exceptions import DateParseError, ProgrammingError
 
 classes = [
     H,
@@ -200,7 +200,7 @@ def test_m_token() -> None:
     assert token._is_minute(tokens) is True
 
     tokens = list(tokenize("m/d/y", classes))
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ProgrammingError) as excinfo:
         token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens)
     assert str(excinfo.value) == "Token is not present in list of tokens"
     token = tokens[0]
@@ -210,7 +210,7 @@ def test_m_token() -> None:
     assert token.format(datetime(2021, 11, 12, 13, 14, 15, 16), tokens) == "14"
     tokens = list(tokenize("m/d/y", classes))
     token = tokens[0]
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ProgrammingError) as excinfo:
         token.format(time(13, 14, 15, 16), tokens)
     assert str(excinfo.value) == "Cannot format value: 13:14:15.000016"
 


### PR DESCRIPTION
## Summary

- Adds a `DateParseError` exception class to `shillelagh/exceptions.py` replacing bare `Exception` raises in date/time parsing code
- Updates `parse_date_time_pattern()` to include the failing value, pattern, and underlying error in the exception message (e.g. `Could not parse '1/2024' using pattern 'm/yyyy': ...`)
- Updates all token `parse()` methods to raise `DateParseError` instead of bare `Exception`

## Motivation

When a Google Sheet has a date column using a format without a day component (e.g. `M/YYYY` like `"1/2024"` instead of `M/D/YYYY` like `"1/1/2024"`), shillelagh raised `Exception("Unsupported format")` with no context about what value or pattern failed. This made it very difficult for Superset users to diagnose the issue.

## Test plan

- [x] Updated all existing tests in `date_test.py` to expect `DateParseError`
- [x] Added `test_parse_date_time_pattern_missing_day()` covering the M/YYYY scenario
- [x] All 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)