### PR TITLE
fix(gsheets): normalize uppercase date/time format patterns

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -26,17 +26,50 @@ TIME_SQL_QUOTE = "%H:%M:%S"
 DURATION_OFFSET = datetime.datetime(1899, 12, 30)
 
 
+def _normalize_pattern(pattern: str) -> str:
+    """
+    Lowercase a date/time pattern outside of its literals.
+
+    The Google Sheets API reports the *default* (non-user-configured) date and
+    datetime formats using an ICU-style pattern with uppercase tokens, e.g.
+    ``M/D/YYYY`` or ``M/d/yyyy H:mm:ss``. The token grammar in
+    ``parsing.date`` is lowercase-only, so these patterns would otherwise fail
+    to parse (or be silently mis-parsed as literals). Literal text is always
+    quoted (``"..."``) or escaped (``\\x``) in patterns returned by the API, so
+    lowercasing everything outside literals is safe and normalizes the
+    uppercase default tokens into ones the parser handles.
+    """
+    result = []
+    i = 0
+    length = len(pattern)
+    while i < length:
+        char = pattern[i]
+        if char == "\\" and i + 1 < length:
+            # escaped literal: keep the backslash and the next char verbatim
+            result.append(pattern[i : i + 2])
+            i += 2
+        elif char == '"':
+            # quoted literal: keep verbatim up to and including the closing quote
+            end = pattern.find('"', i + 1)
+            if end == -1:
+                end = length - 1
+            result.append(pattern[i : end + 1])
+            i = end + 1
+        else:
+            result.append(char.lower())
+            i += 1
+    return "".join(result)
+
+
 class GSheetsField(Field[Internal, External]):
     """
     A base class for GSheets fields.
     """
 
-    # the default formats for date and datetime do not follow the same syntax
-    # as user-configured formats (I suspect it uses ICU instead)
-    pattern_substitutions = {
-        "M/d/yyyy H:mm:ss": "m/d/yyyy h:mm:ss",
-        "M/d/yyyy": "m/d/yyyy",
-    }
+    # Date/time fields set this to normalize the ICU-style pattern reported by
+    # the API (see ``_normalize_pattern``). Number/boolean/string fields keep it
+    # disabled, since e.g. the number format ``General`` must not be lowercased.
+    normalize_pattern_case: bool = False
 
     def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
@@ -47,11 +80,9 @@ class GSheetsField(Field[Internal, External]):
         timezone: Optional[datetime.tzinfo] = None,
     ):
         super().__init__(filters, order, exact)
-        self.pattern: Optional[str] = (
-            self.pattern_substitutions[pattern]
-            if pattern in self.pattern_substitutions
-            else pattern
-        )
+        if pattern is not None and self.normalize_pattern_case:
+            pattern = _normalize_pattern(pattern)
+        self.pattern: Optional[str] = pattern
         self.timezone = timezone
 
     def __eq__(self, other: Any) -> bool:
@@ -88,6 +119,7 @@ class GSheetsDateTime(GSheetsField[str, datetime.datetime]):
 
     type = "TIMESTAMP"
     db_api_type = "DATETIME"
+    normalize_pattern_case = True
 
     def parse(self, value: Optional[str]) -> Optional[datetime.datetime]:
         # Google Chart API returns ``None`` for a NULL cell, while the Google
@@ -142,6 +174,7 @@ class GSheetsDate(GSheetsField[str, datetime.date]):
 
     type = "DATE"
     db_api_type = "DATETIME"
+    normalize_pattern_case = True
 
     def parse(self, value: Optional[str]) -> Optional[datetime.date]:
         # Google Chart API returns ``None`` for a NULL cell, while the Google
@@ -182,6 +215,7 @@ class GSheetsTime(GSheetsField[str, datetime.time]):
 
     type = "TIME"
     db_api_type = "DATETIME"
+    normalize_pattern_case = True
 
     def parse(self, value: Optional[str]) -> Optional[datetime.time]:
         """
@@ -218,6 +252,7 @@ class GSheetsDuration(GSheetsField[str, datetime.timedelta]):
 
     type = "DURATION"
     db_api_type = "DATETIME"
+    normalize_pattern_case = True
 
     def parse(self, value: Optional[str]) -> Optional[datetime.timedelta]:
         if self.pattern is None or value is None or value == "":

--- a/tests/adapters/api/gsheets/fields_test.py
+++ b/tests/adapters/api/gsheets/fields_test.py
@@ -83,6 +83,50 @@ def test_GSheetsDateTime_timezone() -> None:
     )
 
 
+def test_uppercase_default_pattern() -> None:
+    """
+    Test default formats reported with uppercase ICU-style tokens.
+
+    The Google Sheets API reports the default (non-user-configured) date and
+    datetime formats with uppercase tokens, e.g. ``M/D/YYYY``. These must be
+    normalized to the lowercase grammar understood by the parser. Literal text
+    is quoted in the reported patterns, so it is preserved.
+    """
+    assert GSheetsDate(pattern="M/D/YYYY").parse("12/31/2025") == datetime.date(
+        2025,
+        12,
+        31,
+    )
+    assert GSheetsDate(pattern="M/D/YYYY").parse("3/30/2026") == datetime.date(
+        2026,
+        3,
+        30,
+    )
+    assert GSheetsDate(pattern="YYYY-MM-DD").parse("2016-04-05") == datetime.date(
+        2016,
+        4,
+        5,
+    )
+
+    # quoted literals are preserved while the tokens around them are lowercased
+    assert GSheetsDate(pattern='DD"."MM"."YYYY').parse("31.12.2025") == datetime.date(
+        2025,
+        12,
+        31,
+    )
+
+    # month-vs-minute disambiguation still works with uppercase tokens
+    assert GSheetsDateTime(pattern="M/D/YYYY H:MM:SS").parse(
+        "4/5/2016 16:08:53",
+    ) == datetime.datetime(2016, 4, 5, 16, 8, 53)
+
+    # formatting honours the normalized pattern too
+    assert (
+        GSheetsDate(pattern="M/D/YYYY").format(datetime.date(2025, 12, 31))
+        == "12/31/2025"
+    )
+
+
 def test_GSheetsDate() -> None:
     """
     Test ``GSheetsDate``.


### PR DESCRIPTION
## Problem

The Google Sheets API reports default (non-user-configured) date/datetime column formats using uppercase ICU-style tokens — notably the default `M/D/YYYY`. The pattern grammar in `parsing/date.py` is lowercase-only, so these patterns raise `InvalidValue` (e.g. `InvalidValue: 12/31/2025`) or get silently mis-parsed. Downstream (SQLAlchemy / Apache Superset) this surfaces as `Unable to parse ...` errors on any GSheets table whose date column uses a default format.

## Root cause

`GSheetsField` special-cased only two exact strings via `pattern_substitutions` (`M/d/yyyy` and `M/d/yyyy H:mm:ss`). Any other uppercase variant — `M/D/YYYY`, `DD"."MM"."YYYY`, `YYYY-MM-DD`, … — slips through unchanged and then fails the lowercase-only tokenizer.

## Fix

Replace the exact-match lookup with `_normalize_pattern`, which lowercases the pattern **outside of quoted/escaped literals** (literal text is always quoted in API-reported patterns, so this is safe and general). It is applied only to date/time/duration fields via a `normalize_pattern_case` class flag, so number formats such as `General` are left untouched.

## Tests

Added `test_uppercase_default_pattern` (field level), covering `M/D/YYYY`, `YYYY-MM-DD`, a quoted-literal `DD"."MM"."YYYY`, month-vs-minute disambiguation, and formatting. The full `tests/adapters/api/gsheets/` suite passes; the only remaining failure in my environment is the pre-existing `integration_test::test_public_sheet_multicorn`, which requires a live Postgres/multicorn backend.

Two files changed: `fields.py` (fix) and `fields_test.py` (test).
