### PR TITLE
fix(gsheets): default temporal pattern when GViz omits it

### DIFF
--- a/src/shillelagh/adapters/api/gsheets/fields.py
+++ b/src/shillelagh/adapters/api/gsheets/fields.py
@@ -38,6 +38,14 @@ class GSheetsField(Field[Internal, External]):
         "M/d/yyyy": "m/d/yyyy",
     }
 
+    # The Google Chart API sometimes types a column as temporal without
+    # returning the optional ``pattern`` describing its format. Temporal
+    # subclasses set this to Google's documented default so that a missing
+    # pattern still parses/formats/quotes values correctly instead of falling
+    # back to ``None`` (which turns valid values -- including filter bounds --
+    # into the literal ``null``). Non-temporal fields leave this as ``None``.
+    default_pattern: Optional[str] = None
+
     def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         filters: Optional[list[type[Filter]]] = None,
@@ -47,6 +55,8 @@ class GSheetsField(Field[Internal, External]):
         timezone: Optional[datetime.tzinfo] = None,
     ):
         super().__init__(filters, order, exact)
+        if pattern is None:
+            pattern = self.default_pattern
         self.pattern: Optional[str] = (
             self.pattern_substitutions[pattern]
             if pattern in self.pattern_substitutions
@@ -88,6 +98,7 @@ class GSheetsDateTime(GSheetsField[str, datetime.datetime]):
 
     type = "TIMESTAMP"
     db_api_type = "DATETIME"
+    default_pattern = "M/d/yyyy H:mm:ss"
 
     def parse(self, value: Optional[str]) -> Optional[datetime.datetime]:
         # Google Chart API returns ``None`` for a NULL cell, while the Google
@@ -142,6 +153,7 @@ class GSheetsDate(GSheetsField[str, datetime.date]):
 
     type = "DATE"
     db_api_type = "DATETIME"
+    default_pattern = "M/d/yyyy"
 
     def parse(self, value: Optional[str]) -> Optional[datetime.date]:
         # Google Chart API returns ``None`` for a NULL cell, while the Google
@@ -182,6 +194,7 @@ class GSheetsTime(GSheetsField[str, datetime.time]):
 
     type = "TIME"
     db_api_type = "DATETIME"
+    default_pattern = "h:mm:ss am/pm"
 
     def parse(self, value: Optional[str]) -> Optional[datetime.time]:
         """
@@ -218,6 +231,7 @@ class GSheetsDuration(GSheetsField[str, datetime.timedelta]):
 
     type = "DURATION"
     db_api_type = "DATETIME"
+    default_pattern = "[h]:mm:ss"
 
     def parse(self, value: Optional[str]) -> Optional[datetime.timedelta]:
         if self.pattern is None or value is None or value == "":

--- a/tests/adapters/api/gsheets/fields_test.py
+++ b/tests/adapters/api/gsheets/fields_test.py
@@ -163,6 +163,55 @@ def test_GSheetsDuration() -> None:
     )
 
 
+def test_temporal_default_pattern() -> None:
+    """
+    Test that temporal fields fall back to a default pattern.
+
+    The Google Chart API sometimes types a column as temporal without returning
+    the optional ``pattern`` describing its format. In that case the field
+    should fall back to Google's documented default so that non-null values --
+    including filter bounds -- are parsed, formatted, and quoted correctly
+    instead of collapsing to the literal ``null``.
+    """
+    assert GSheetsDateTime().default_pattern == "M/d/yyyy H:mm:ss"
+    assert GSheetsDate().default_pattern == "M/d/yyyy"
+    assert GSheetsTime().default_pattern == "h:mm:ss am/pm"
+    assert GSheetsDuration().default_pattern == "[h]:mm:ss"
+
+    # Non-temporal fields keep the ``None`` default (no substitution applied).
+    assert GSheetsString().default_pattern is None
+
+    # Without a pattern, a non-null value now parses instead of returning ``None``.
+    assert GSheetsDateTime().parse("12/31/2020 12:34:56") == datetime.datetime(
+        2020,
+        12,
+        31,
+        12,
+        34,
+        56,
+    )
+    assert GSheetsDate().parse("12/31/2020") == datetime.date(2020, 12, 31)
+    assert GSheetsTime().parse("12:34:56 AM") == datetime.time(0, 34, 56)
+    assert GSheetsDuration().parse("12:34:56") == datetime.timedelta(
+        hours=12,
+        minutes=34,
+        seconds=56,
+    )
+
+    # ... and is quoted as a valid literal instead of ``null``.
+    assert (
+        GSheetsDateTime().quote("12/31/2020 12:34:56")
+        == "datetime '2020-12-31 12:34:56'"
+    )
+    assert GSheetsDate().quote("12/31/2020") == "date '2020-12-31'"
+    assert GSheetsTime().quote("12:34:56 AM") == "timeofday '00:34:56'"
+    assert GSheetsDuration().quote("12:34:56") == "datetime '1899-12-30 12:34:56'"
+
+    # Genuine NULL / empty values are still quoted as ``null``.
+    assert GSheetsDateTime().quote(None) == "null"
+    assert GSheetsDate().quote("") == "null"
+
+
 def test_GSheetsBoolean() -> None:
     """
     Test ``GSheetsBoolean``.


### PR DESCRIPTION
# Summary

The Google Chart (GViz) API can type a column as temporal (`date`, `datetime`, `timeofday` or `duration`) while omitting the optional `pattern` that describes its format. When that happens, `get_field()` builds the field with `pattern=None`, and the temporal fields treat a missing pattern as "no value":

- `GSheetsField.format()` returns `""`,
- `GSheetsField.quote()` returns the literal string `"null"`,
- `GSheetsField.parse()` returns `None`.

For filtering this is a real problem. The virtual-table layer computes each filter bound as `field.format(value)` and then quotes it, so a valid range on a pattern-less temporal column is turned into:

```sql
WHERE col >= null AND col < null
```

which Google rejects with `Invalid query: NO_COLUMN: null`. Pattern-less temporal **cells** are affected too — they silently `parse()` to `None`.

## Fix

Give each temporal field a `default_pattern` set to Google's documented default format, and have `GSheetsField.__init__` fall back to it when no pattern is provided:

| Field | `default_pattern` |
|---|---|
| `GSheetsDateTime` | `M/d/yyyy H:mm:ss` |
| `GSheetsDate` | `M/d/yyyy` |
| `GSheetsTime` | `h:mm:ss am/pm` |
| `GSheetsDuration` | `[h]:mm:ss` |

Because `parse`, `format` and `quote` all key off `self.pattern`, defaulting it in one place repairs all three. Non-temporal fields keep `default_pattern = None` and are unaffected. The default runs through the existing `pattern_substitutions` map, exactly like a user-provided pattern.

This only changes behavior on the previously-broken path (a temporal column with no pattern). Genuine `None`/empty values are still quoted as `null`, and columns that already carry a pattern are unchanged.

# Testing instructions

- `make test` — all unit tests pass and coverage stays at 100%.
- New regression test `test_temporal_default_pattern` in `tests/adapters/api/gsheets/fields_test.py` asserts that, without an explicit pattern, each temporal field now:
  - exposes its documented `default_pattern`,
  - `parse()`s a real value instead of returning `None`,
  - `quote()`s a real value to a valid literal (e.g. `datetime '2020-12-31 12:34:56'`, `date '2020-12-31'`, `timeofday '00:34:56'`, `datetime '1899-12-30 12:34:56'`) instead of `null`,
  - still returns `null` for genuine `None`/empty values.
- Existing `fields_test.py` / `lib_test.py` assertions are unchanged: `get_field(...)` equality checks still hold because both sides go through the same constructor.

Before this change, a pattern-less temporal column produced `col >= null AND col < null`; after it, the same filter produces a valid bounded predicate.
